### PR TITLE
Update prometheus-serviceMonitorEtcd.yaml.j2

### DIFF
--- a/roles/ks-monitor/templates/prometheus-serviceMonitorEtcd.yaml.j2
+++ b/roles/ks-monitor/templates/prometheus-serviceMonitorEtcd.yaml.j2
@@ -15,7 +15,6 @@ spec:
       caFile: /etc/prometheus/secrets/kube-etcd-client-certs/etcd-client-ca.crt
       certFile: /etc/prometheus/secrets/kube-etcd-client-certs/etcd-client.crt
       keyFile: /etc/prometheus/secrets/kube-etcd-client-certs/etcd-client.key
-      serverName: etcd.kube-system.svc.cluster.local
 {% endif %}
   jobLabel: k8s-app
   namespaceSelector:


### PR DESCRIPTION
don't hardcode server name. hostname verification may fail. Fix #31 