### PR TITLE
java8 should user java8 runtime, java11 use java11 runtime

### DIFF
--- a/roles/ks-devops/s2i/templates/java.yaml.j2
+++ b/roles/ks-devops/s2i/templates/java.yaml.j2
@@ -11,12 +11,12 @@ metadata:
     "helm.sh/hook": pre-install
 spec:
   containerInfo:
-     - builderImage: {{ java11centos7_repo }}:{{ ks_image_tag }}
+     - builderImage: {{ java8centos7_repo }}:{{ ks_image_tag }}
        runtimeImage: {{ java8_runtime_repo }}:{{ ks_image_tag }}
        runtimeArtifacts:
          - source: "/deployments"
        buildVolumes: ["s2i_java_cache:/tmp/artifacts"]
-     - builderImage: {{ java8centos7_repo }}:{{ ks_image_tag }}
+     - builderImage: {{ java11centos7_repo }}:{{ ks_image_tag }}
        runtimeImage: {{ java11_runtime_repo }}:{{ ks_image_tag }}
        runtimeArtifacts:
          - source: "/deployments"


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>
@pixiake 