### PR TITLE
retry ks-account 60

### DIFF
--- a/roles/ks-devops/jenkins/tasks/check_sonar.yaml
+++ b/roles/ks-devops/jenkins/tasks/check_sonar.yaml
@@ -2,7 +2,7 @@
   shell: "{{ bin_dir }}/kubectl get pod -n kubesphere-system -o wide | grep ks-account | awk '{print $3}'"
   register: result
   until: result.stdout.find("Running") != -1
-  retries: 30
+  retries: 60
   delay: 10
   when:
     - devops.sonarqube.enabled is defined


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>
@pixiake 
```
TASK [ks-devops/jenkins : KubeSphere | Waiting for ks-account] *****************
FAILED - RETRYING: KubeSphere | Waiting for ks-account (30 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (29 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (28 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (27 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (26 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (25 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (24 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (23 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (22 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (21 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (20 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (19 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (18 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (17 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (16 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (15 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (14 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (13 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (12 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (11 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (10 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (9 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (8 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (7 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (6 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (5 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (4 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (3 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (2 retries left).
FAILED - RETRYING: KubeSphere | Waiting for ks-account (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 30, "changed": true, "cmd": "/usr/local/bin/kubectl get pod -n kubesphere-system -o wide | grep ks-account | awk '{print $3}'", "delta": "0:00:00.269275", "end": "2019-10-16 20:05:04.564815", "rc": 0, "start": "2019-10-16 20:05:04.295540", "stderr": "", "stderr_lines": [], "stdout": "PodInitializing", "stdout_lines": ["PodInitializing"]}
```