### PR TITLE
fix namesapced policy rules

### DIFF
--- a/roles/ks-core/prepare/templates/ks-account-init.yaml.j2
+++ b/roles/ks-core/prepare/templates/ks-account-init.yaml.j2
@@ -1492,8 +1492,7 @@ data:
                   "create"
                 ],
                 "apiGroups": [
-                  "devops.kubesphere.io",
-                  "resources.kubesphere.io"
+                  "devops.kubesphere.io"
                 ],
                 "resources": [
                   "s2ibuilders",
@@ -1511,8 +1510,7 @@ data:
                   "patch"
                 ],
                 "apiGroups": [
-                  "devops.kubesphere.io",
-                  "resources.kubesphere.io"
+                  "devops.kubesphere.io"
                 ],
                 "resources": [
                   "s2ibuilders",
@@ -1529,8 +1527,7 @@ data:
                   "delete"
                 ],
                 "apiGroups": [
-                  "devops.kubesphere.io",
-                  "resources.kubesphere.io"
+                  "devops.kubesphere.io"
                 ],
                 "resources": [
                   "s2ibuilders",

--- a/roles/ks-core/prepare/templates/ks-apigateway-init.yaml.j2
+++ b/roles/ks-core/prepare/templates/ks-apigateway-init.yaml.j2
@@ -8,12 +8,12 @@ data:
         redis-url redis://redis.kubesphere-system.svc:6379
         secret {$JWT_SECRET}
         path /
-        except /apis/account.kubesphere.io/v1alpha1/authenticate,/kapis/iam.kubesphere.io/v1alpha2/login,/kapis/iam.kubesphere.io/v1alpha2/authenticate,/images,/kapis/devops.kubesphere.io/v1alpha2/webhook/github,/kapis/devops.kubesphere.io/v1alpha2/webhook/git,/swagger
+        except /apis/account.kubesphere.io/v1alpha1/authenticate,/kapis/iam.kubesphere.io/v1alpha2/login,/kapis/iam.kubesphere.io/v1alpha2/authenticate,/images,/kapis/devops.kubesphere.io/v1alpha2/webhook/github,/kapis/devops.kubesphere.io/v1alpha2/webhook/git,/swagger,/kapis/v1alpha1/configz
       }
 
       authentication {
         path /
-        except /kapis/tenant.kubesphere.io/v1alpha2,/kapis/alerting.kubesphere.io/v1/comment,/kapis/alerting.kubesphere.io/v1/resource_type,/kapis/alerting.kubesphere.io/v1/metric,/kapis/notification.kubesphere.io,/kapis/resources.kubesphere.io/v1alpha2/registry,/kapis/iam.kubesphere.io/v1alpha2/rulesmapping,/kapis/jenkins.kubesphere.io,/kapis/devops.kubesphere.io,/apis/devops.kubesphere.io,/kapis/v1alpha1/configz
+        except /kapis/tenant.kubesphere.io/v1alpha2,/kapis/alerting.kubesphere.io/v1/comment,/kapis/alerting.kubesphere.io/v1/resource_type,/kapis/alerting.kubesphere.io/v1/metric,/kapis/notification.kubesphere.io,/kapis/resources.kubesphere.io/v1alpha2/registry,/kapis/iam.kubesphere.io/v1alpha2/rulesmapping,/kapis/jenkins.kubesphere.io,/kapis/devops.kubesphere.io,/apis/devops.kubesphere.io
       }
       
       swagger


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

1. Fix project operator can not build image. #https://github.com/kubesphere/kubesphere/issues/1113
2. Allow anonymous access to `/kapis/v1alpha1/configz`.