### PR TITLE
monitor: rename services to avoid conflicts in HA environments

### DIFF
--- a/roles/ks-monitor/files/prometheus/sources/prometheus-serviceKubeControllerManager.yaml
+++ b/roles/ks-monitor/files/prometheus/sources/prometheus-serviceKubeControllerManager.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     k8s-app: kube-controller-manager
-  name: kube-controller-manager
+  name: kube-controller-manager-headless
   namespace: kube-system
 spec:
   clusterIP: None

--- a/roles/ks-monitor/files/prometheus/sources/prometheus-serviceKubeScheduler.yaml
+++ b/roles/ks-monitor/files/prometheus/sources/prometheus-serviceKubeScheduler.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     k8s-app: kube-scheduler
-  name: kube-scheduler
+  name: kube-scheduler-headless
   namespace: kube-system
 spec:
   clusterIP: None


### PR DESCRIPTION
Fixes #393 

refer to https://github.com/kubesphere/prometheus-operator/pull/15

Signed-off-by: huanggze <loganhuang@yunify.com>