### PR TITLE
add kubesphere prefix to names of rbac resources for monitoring

### DIFF
--- a/roles/ks-monitor/files/prometheus/init/0prometheus-operator-clusterRole.yaml
+++ b/roles/ks-monitor/files/prometheus/init/0prometheus-operator-clusterRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-operator
+  name: kubesphere-prometheus-operator
 rules:
   - apiGroups:
       - apiextensions.k8s.io

--- a/roles/ks-monitor/files/prometheus/init/0prometheus-operator-clusterRoleBinding.yaml
+++ b/roles/ks-monitor/files/prometheus/init/0prometheus-operator-clusterRoleBinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-operator
+  name: kubesphere-prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-operator
+  name: kubesphere-prometheus-operator
 subjects:
   - kind: ServiceAccount
     name: prometheus-operator

--- a/roles/ks-monitor/files/prometheus/sources/kube-state-metrics-clusterRole.yaml
+++ b/roles/ks-monitor/files/prometheus/sources/kube-state-metrics-clusterRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kube-state-metrics
+  name: kubesphere-kube-state-metrics
 rules:
   - apiGroups:
       - ""

--- a/roles/ks-monitor/files/prometheus/sources/kube-state-metrics-clusterRoleBinding.yaml
+++ b/roles/ks-monitor/files/prometheus/sources/kube-state-metrics-clusterRoleBinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kube-state-metrics
+  name: kubesphere-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kube-state-metrics
+  name: kubesphere-kube-state-metrics
 subjects:
   - kind: ServiceAccount
     name: kube-state-metrics

--- a/roles/ks-monitor/files/prometheus/sources/node-exporter-clusterRole.yaml
+++ b/roles/ks-monitor/files/prometheus/sources/node-exporter-clusterRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: node-exporter
+  name: kubesphere-node-exporter
 rules:
   - apiGroups:
       - authentication.k8s.io

--- a/roles/ks-monitor/files/prometheus/sources/node-exporter-clusterRoleBinding.yaml
+++ b/roles/ks-monitor/files/prometheus/sources/node-exporter-clusterRoleBinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: node-exporter
+  name: kubesphere-node-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: node-exporter
+  name: kubesphere-node-exporter
 subjects:
   - kind: ServiceAccount
     name: node-exporter

--- a/roles/ks-monitor/files/prometheus/sources/prometheus-clusterRole.yaml
+++ b/roles/ks-monitor/files/prometheus/sources/prometheus-clusterRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-k8s
+  name: kubesphere-prometheus-k8s
 rules:
   - apiGroups:
       - ""

--- a/roles/ks-monitor/files/prometheus/sources/prometheus-clusterRoleBinding.yaml
+++ b/roles/ks-monitor/files/prometheus/sources/prometheus-clusterRoleBinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-k8s
+  name: kubesphere-prometheus-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-k8s
+  name: kubesphere-prometheus-k8s
 subjects:
   - kind: ServiceAccount
     name: prometheus-k8s


### PR DESCRIPTION
This PR is to avoid rbac naming conflicts in environments such as Openshift 

Signed-off-by: huanggze <loganhuang@yunify.com>