### PR TITLE
bump kube-state-metrics version to 1.7.2

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -324,8 +324,8 @@ prometheus_operator_repo: "{{ base_repo }}kubesphere/prometheus-operator"
 prometheus_operator_tag: v0.34.0
 kube_rbac_proxy_repo: "{{ base_repo }}kubesphere/kube-rbac-proxy"
 kube_rbac_proxy_tag: v0.4.1
-kube_state_metrics_repo: "{{ base_repo }}kubesphere/kube-state-metrics"
-kube_state_metrics_tag: v1.5.2
+kube_state_metrics_repo: "{{ quay_image_repo }}/coreos/kube-state-metrics"
+kube_state_metrics_tag: v1.7.2
 node_exporter_repo: "{{ base_repo }}kubesphere/node-exporter"
 node_exporter_tag: ks-v0.16.0
 addon_resizer_repo: "{{ base_repo }}kubesphere/addon-resizer"


### PR DESCRIPTION
bump version to support appsv1 apigroup resources

Signed-off-by: huanggze <loganhuang@yunify.com>