### PR TITLE
make the auditing send alert to alertmanager by default

### DIFF
--- a/roles/ks-auditing/templates/custom-values.yaml.j2
+++ b/roles/ks-auditing/templates/custom-values.yaml.j2
@@ -36,7 +36,14 @@ webhook:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  receivers: []
+  receivers:
+    - name: alert
+      type: alertmanager
+      config:
+        service:
+          namespace: kubesphere-monitoring-system
+          name: alertmanager-main
+          port: 9093
   priority: DEBUG
   auditType: dynamic
   auditLevel: Metadata


### PR DESCRIPTION
Signed-off-by: wanjunlei wanjunlei@yunify.com