### PR TITLE
fix jaeger-operator chart bug

### DIFF
--- a/roles/ks-istio/tasks/main.yaml
+++ b/roles/ks-istio/tasks/main.yaml
@@ -29,6 +29,7 @@
     - istio-system
     - kube-system
     - kubesphere-system
+    - kubesphere-devops-system
 #    - openpitrix-system
 
 - name: istio | Check istio


### PR DESCRIPTION
Signed-off-by: zackzhangkai <zackzhang@yunify.com>

fix selector of jaeger-operator service not match pod label