### PR TITLE
It is better to put localhost for etcd monitoring since people usuall…

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -11,7 +11,7 @@ spec:
     storageClass: ""
   etcd:
     monitoring: false
-    endpointIps: 192.168.0.7,192.168.0.8,192.168.0.9
+    endpointIps: localhost
     port: 2379
     tlsEnable: true
   common:

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -7,7 +7,7 @@ persistence:
   storageClass: ""
 etcd:
   monitoring: false
-  endpointIps: 192.168.0.7,192.168.0.8,192.168.0.9
+  endpointIps: localhost
   port: 2379
   tlsEnable: true
 common:

--- a/kubesphere-complete-setup.yaml
+++ b/kubesphere-complete-setup.yaml
@@ -15,7 +15,7 @@ data:
 
     etcd:
       monitoring: False
-      endpointIps: 192.168.0.7,192.168.0.8,192.168.0.9
+      endpointIps: localhost
       port: 2379
       tlsEnable: True
 


### PR DESCRIPTION
…y start an allinone installation.

Why here still show etcd monitoring disabled by default? Also some place using the capital True/False, other place using lower case true/false.