### PR TITLE
retry when fluent bit operator fails to deploy

### DIFF
--- a/roles/ks-logging/tasks/main.yaml
+++ b/roles/ks-logging/tasks/main.yaml
@@ -102,6 +102,10 @@
     - {path: logging, file: custom-output-elasticsearch.yaml}
     - {path: logging, file: custom-output-elasticsearch-events.yaml}
     - {path: logging, file: custom-output-elasticsearch-auditing.yaml}
+  register: import
+  until: import is succeeded
+  retries: 5
+  delay: 3
 
 - name: ks-logging | Check elasticsearch
   shell: >


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

Deployment may fail becasue CRDs are just applied and not ready.