### PR TITLE
fix ws self-provisioner can't open project page

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -1762,6 +1762,12 @@ role:
     - get
     - list
     - watch
+  - apiGroups:
+    - monitoring.kubesphere.io
+    resources:
+    - namespaces
+    verbs:
+    - list
 
 ---
 apiVersion: iam.kubesphere.io/v1alpha2
@@ -1793,6 +1799,12 @@ role:
     - devops
     verbs:
     - create
+  - apiGroups:
+    - monitoring.kubesphere.io
+    resources:
+    - namespaces
+    verbs:
+    - list
 
 ---
 apiVersion: iam.kubesphere.io/v1alpha2


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/2302