### PR TITLE
Remove notification switch from monitoring

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -53,8 +53,6 @@ spec:
     prometheusMemoryRequest: 400Mi
     prometheusVolumeSize: 20Gi
     alertmanagerReplicas: 1
-    notification:
-      enabled: false
   multicluster:
     clusterRole: none  # host | member | none
   networkpolicy:

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -49,8 +49,6 @@ monitoring:
   prometheusMemoryRequest: 400Mi
   prometheusVolumeSize: 20Gi
   alertmanagerReplicas: 1
-  notification:
-    enabled: false
 multicluster:
   # host: means installer will install current cluster as a Host Cluster. There should be only one HOST CLUSTER in KubeSphere multicluster.
   # member: means installer will install current cluster as a Member Cluster

--- a/roles/ks-monitor/tasks/main.yaml
+++ b/roles/ks-monitor/tasks/main.yaml
@@ -41,6 +41,8 @@
   when:
     - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
 
+- import_tasks: notification-manager.yaml
+
 - import_tasks: monitoring-dashboard.yaml
   when:
     - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
@@ -58,10 +60,3 @@
   delay: 3
   when:
     - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: notification-manager.yaml
-  when:
-    - monitoring.notification is defined
-    - monitoring.notification.enabled is defined 
-    - monitoring.notification.enabled == true 
-    - "status.monitoring.notification is not defined or status.monitoring.notification.status is not defined or status.monitoring.notification.status != 'enabled'"

--- a/roles/ks-monitor/tasks/notification-manager.yaml
+++ b/roles/ks-monitor/tasks/notification-manager.yaml
@@ -33,15 +33,3 @@
   delay: 10
   when:
     - (notification_check.stdout.find("DEPLOYED") == -1) or (notification_check.stdout.find("v1.0.0") == -1)
-
-- name: notification-manager | import notification-manager status
-  shell: >
-    {{ bin_dir }}/kubectl patch cc ks-installer
-    --type merge
-    -p '{"status": {"monitoring": {"notification": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}}'
-    -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
-  retries: 5
-  delay: 3

--- a/roles/ks-monitor/templates/custom-values-notification.yaml.j2
+++ b/roles/ks-monitor/templates/custom-values-notification.yaml.j2
@@ -12,8 +12,8 @@ operator:
           cpu: 50m
           memory: 50Mi
         requests:
-          cpu: 20m
-          memory: 20Mi
+          cpu: 5m
+          memory: 10Mi
     operator:
       image:
         repo: {{ notification_manager_operator_repo }}
@@ -24,8 +24,8 @@ operator:
           cpu: 50m
           memory: 50Mi
         requests:
-          cpu: 50m
-          memory: 50Mi
+          cpu: 5m
+          memory: 20Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -44,8 +44,8 @@ notificationmanager:
       cpu: 500m
       memory: 500Mi
     requests:
-      cpu: 50m
-      memory: 50Mi
+      cpu: 5m
+      memory: 20Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/src/kubesphere/roles/ks-installer/files/ks-installer/ks-installer-config.yaml
+++ b/src/kubesphere/roles/ks-installer/files/ks-installer/ks-installer-config.yaml
@@ -35,8 +35,6 @@ data:
       prometheusVolumeSize: {{ prometheus_volume_size }}
       grafana:
         enabled: {{ grafana_enabled }}
-      notification:
-        enabled: {{ notification_enabled  }}
 
     logging:
       enabled: {{ logging_enabled }}

--- a/src/kubesphere/roles/ks-installer/templates/ks-installer-config.yaml.j2
+++ b/src/kubesphere/roles/ks-installer/templates/ks-installer-config.yaml.j2
@@ -34,8 +34,6 @@ data:
       alertmanagerReplicas: {{ alertmanager_replicas | default(3) }}
       grafana:
         enabled: {{ grafana_enabled | string | lower }}
-      notification:
-        enabled: {{ notification_enabled | string | lower }}      
 
     logging:
       enabled: {{ logging_enabled | string | lower }}


### PR DESCRIPTION
Notification Manager should be installed by default because Alertmanager is installed by default.
The notification switch under monitoring might be confusing with the notification switch in upper level.

Signed-off-by: Benjamin <benjamin@yunify.com>