### PR TITLE
fix: regular user can't list storageclasses

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -1819,6 +1819,7 @@ role:
     - devops
     verbs:
     - create
+    - watch
   - apiGroups:
     - monitoring.kubesphere.io
     resources:

--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -142,11 +142,21 @@ rules:
     verbs:
       - list
   - apiGroups:
-      - storage.k8s.io
+      - '*'
     resources:
       - storageclasses
     verbs:
       - get
+      - list
+  - apiGroups:
+    - openpitrix.io
+    resources:
+    - apps
+    - apps/versions
+    - categories
+    verbs:
+    - get
+    - list
 
 
 ---
@@ -177,16 +187,7 @@ metadata:
     iam.kubesphere.io/aggregation-roles: '["role-template-view-app-templates"]'
     kubesphere.io/creator: admin
   name: platform-regular
-rules:
-- apiGroups:
-  - openpitrix.io
-  resources:
-  - apps
-  - apps/versions
-  - categories
-  verbs:
-  - get
-  - list
+rules: []
 
 ---
 apiVersion: iam.kubesphere.io/v1alpha2


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/2396