### PR TITLE
Allow S2I job fetch s2ibinaries

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -82,6 +82,12 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - devops.kubesphere.io
+    resources:
+      - s2ibinaries/file
+    verbs:
+      - get
 
 ---
 apiVersion: iam.kubesphere.io/v1alpha2


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/2502