### PR TITLE
fix: self-provisioner can't create fed project

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -999,6 +999,7 @@ rules:
   - 'federatednamespaces'
   verbs:
   - 'create'
+  - 'watch'
 
 ---
 apiVersion: iam.kubesphere.io/v1alpha2
@@ -1153,6 +1154,7 @@ rules:
   - 'devopsprojects'
   verbs:
   - 'create'
+  - 'watch'
 
 ---
 apiVersion: iam.kubesphere.io/v1alpha2
@@ -1835,6 +1837,7 @@ role:
     - '*'
     resources:
     - namespaces
+    - federatednamespaces
     - devops
     verbs:
     - create


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/2549