### PR TITLE
fix can't list multi cluster pods

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -993,6 +993,18 @@ rules:
 - apiGroups:
   - '*'
   resources:
+  - workspaces
+  - workspacemembers
+  - quotas
+  - abnormalworkloads
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
   - 'namespaces'
   - 'federatednamespaces'
   verbs:
@@ -1840,6 +1852,7 @@ role:
     - workspacemembers
     - quotas
     - abnormalworkloads
+    - pods
     verbs:
     - get
     - list


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/2555