### PR TITLE
fix: workspaces-manager cannot view logs

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -289,6 +289,7 @@ rules:
   - ingresses
   - filters
   - pods
+  - pods/log
   - namespacenetworkpolicies
   - workspacenetworkpolicies
   - ingresses


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

Fix https://github.com/kubesphere/kubesphere/issues/2663