### PR TITLE
fix: miss pods/log in workspace role templates

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -622,6 +622,7 @@ rules:
   - ingresses
   - filters
   - pods
+  - pods/log
   - namespacenetworkpolicies
   - workspacenetworkpolicies
   - ingresses
@@ -725,6 +726,7 @@ rules:
   - ingresses
   - filters
   - pods
+  - pods/log
   - namespacenetworkpolicies
   - workspacenetworkpolicies
   - ingresses


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

![image](https://user-images.githubusercontent.com/22350668/88512617-6e35c980-d019-11ea-9553-3ef94cc8810f.png)

```
$ kubectl get  globalrole  role-template-manage-workspaces  role-template-view-workspaces
NAME                              AGE
role-template-manage-workspaces   3d
role-template-view-workspaces     3d
```