### PR TITLE
add archivingPriority and alertingPriority to kube-auditing-webhook

### DIFF
--- a/roles/ks-auditing/files/kube-auditing/templates/webhook_cr.yaml
+++ b/roles/ks-auditing/files/kube-auditing/templates/webhook_cr.yaml
@@ -22,7 +22,8 @@ spec:
     {{- toYaml .Values.webhook.resources | nindent 4 }}
   receivers:
     {{- toYaml .Values.webhook.receivers | nindent 4 }}
-  priority: {{ .Values.webhook.priority }}
+  archivingPriority: {{ .Values.webhook.archivingPriority }}
+  alertingPriority: {{ .Values.webhook.alertingPriority }}
   auditType: {{ .Values.webhook.auditType }}
   auditLevel: {{ .Values.webhook.auditLevel }}
   k8sAuditingEnabled: {{ .Values.webhook.k8sAuditingEnabled }}

--- a/roles/ks-auditing/templates/custom-values.yaml.j2
+++ b/roles/ks-auditing/templates/custom-values.yaml.j2
@@ -44,7 +44,8 @@ webhook:
           namespace: kubesphere-monitoring-system
           name: alertmanager-main
           port: 9093
-  priority: DEBUG
+  archivingPriority: DEBUG
+  alertingPriority: WARNING
   auditType: dynamic
   auditLevel: Metadata
   k8sAuditingEnabled: false


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

add alertingPriority to controll whether the rule triggers an alert， add archivingPriority to controll whether the auditing log will be stored