### PR TITLE
fix jaeger-operator service

### DIFF
--- a/roles/ks-istio/files/istio/jaeger-operator-service.yaml
+++ b/roles/ks-istio/files/istio/jaeger-operator-service.yaml
@@ -12,8 +12,6 @@ spec:
       protocol: TCP
       targetPort: 8383
   selector:
-    app.kubernetes.io/instance: jaeger-operator
-    app.kubernetes.io/managed-by: Tiller
-    app.kubernetes.io/name: jaeger-operator
+    name: jaeger-operator
   sessionAffinity: None
   type: ClusterIP


### PR DESCRIPTION
the jaeger-operator service selector not match the labels of jaeger-operator pod