### PR TITLE
migrate prometheus crd

### DIFF
--- a/roles/ks-monitor/tasks/get_old_config.yaml
+++ b/roles/ks-monitor/tasks/get_old_config.yaml
@@ -12,3 +12,32 @@
     - prometheus_pvc.rc == 0
     - prometheus_pvc.stdout != ""
   ignore_errors: True
+
+- name: Logging | Check prometheus retention days
+  shell: >
+    {{ bin_dir }}/kubectl get prometheuses.monitoring.coreos.com -n kubesphere-monitoring-system k8s -o jsonpath='{.spec.retention}'
+  register: prometheus_retention
+  ignore_errors: True
+
+- name: Logging | Setting prometheus retention days
+  set_fact:
+    prometheus_retention_duration: "{{ prometheus_retention.stdout }}"
+  when:
+    - prometheus_retention.rc == 0
+    - prometheus_retention.stdout != ""
+  ignore_errors: True
+
+- name: Logging | Check prometheus node selector
+  shell: |
+    {{ bin_dir }}/kubectl get prometheuses.monitoring.coreos.com -n kubesphere-monitoring-system k8s -o go-template --template="{{ '{{' }}range \$key, \$value := .spec.nodeSelector{{ '}}' }}    {{ '{{' }}\$key{{ '}}' }}: {{ '{{' }}\$value{{ '}}' }}
+    {{ '{{' }}end{{ '}}' }}"
+  register: prometheus_node_selector
+  ignore_errors: True
+
+- name: Logging | Setting prometheus node selector
+  set_fact:
+    prometheus_node_selector_map: "{{ prometheus_node_selector.stdout }}"
+  when:
+    - prometheus_node_selector.rc == 0
+    - prometheus_node_selector.stdout != ""
+  ignore_errors: True

--- a/roles/ks-monitor/templates/prometheus-prometheus.yaml.j2
+++ b/roles/ks-monitor/templates/prometheus-prometheus.yaml.j2
@@ -37,7 +37,11 @@ spec:
       port: web
   image: {{ prometheus_repo }}:{{ prometheus_tag }}
   nodeSelector:
+{% if prometheus_node_selector_map is defined %}
+{{ prometheus_node_selector_map }}
+{% else %}
     kubernetes.io/os: linux
+{% endif %}
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   query:
@@ -50,7 +54,8 @@ spec:
     requests:
       cpu: {{ monitoring.prometheus.requests.cpu | default("200m") }}
       memory: {{ monitoring.prometheus.requests.memory | default("400Mi") }}
-  retention: 7d
+  retention: {% if prometheus_retention_duration is defined %}{{ prometheus_retention_duration }}{% else %}7d{% endif %}
+
   ruleSelector:
     matchLabels:
       prometheus: k8s


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

Migrating `spec.retention` and `spec.nodeSelector`.