### PR TITLE
allow list services even if not invited to the namespace

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
+++ b/roles/ks-core/prepare/files/ks-init/iam-accounts.yaml
@@ -196,6 +196,7 @@ rules:
       - resources.kubesphere.io
     resources:
       - namespaces
+      - services
     verbs:
       - list
   - apiGroups:


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/2926