### PR TITLE
Set the default value of Jenkins HealthProbes as true

### DIFF
--- a/roles/ks-devops/jenkins/templates/custom-values-jenkins.yaml.j2
+++ b/roles/ks-devops/jenkins/templates/custom-values-jenkins.yaml.j2
@@ -14,7 +14,7 @@ Master:
   ServicePort: 80
   ServiceType: NodePort
   NodePort: 30180
-  HealthProbes: false
+  HealthProbes: true
 
   InitContainerEnv:
     - name: JENKINS_UC_DOWNLOAD


### PR DESCRIPTION
The health status of Jenkins should keep align with the real status instead of status of Pod
