### PR TITLE
if snapshot controller exist, ignore deploy failed

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -69,6 +69,8 @@
         {{ kubesphere_dir }}/snapshot-controller
         -f {{ kubesphere_dir }}/custom-values-snapshot-controller.yaml
         --namespace kube-system
+      failed_when: false
+
   when:
     - kubernetes_version.stdout is version('v1.17.0', '>=')
 


### PR DESCRIPTION
Signed-off-by: zhangmin <arminzhang@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/3137