### PR TITLE
change rolling update strategy

### DIFF
--- a/roles/ks-core/ks-core/templates/ks-apiserver.yml.j2
+++ b/roles/ks-core/ks-core/templates/ks-apiserver.yml.j2
@@ -10,7 +10,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 0
+      maxSurge: 25%
     type: RollingUpdate
 {% if master_num is defined and master_num != "0" %}
   replicas: {{ master_num }}

--- a/roles/ks-core/ks-core/templates/ks-console-deployment.yml.j2
+++ b/roles/ks-core/ks-core/templates/ks-console-deployment.yml.j2
@@ -10,7 +10,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 0
+      maxSurge: 25%
     type: RollingUpdate
 {% if master_num is defined and master_num != "0" %}
   replicas: {{ master_num }}

--- a/roles/ks-core/ks-core/templates/ks-controller-manager.yaml.j2
+++ b/roles/ks-core/ks-core/templates/ks-controller-manager.yaml.j2
@@ -10,7 +10,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 0
+      maxSurge: 25%
     type: RollingUpdate
   progressDeadlineSeconds: 600
 {% if master_num is defined and master_num != "0" %}


### PR DESCRIPTION

The strategy currently is not safe, which delete the pod immediately

Signed-off-by: zackzhangkai <zackzhang@yunify.com>

/assign @pixiake 