### PR TITLE
Add a GitHub action for nightly build

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,0 +1,48 @@
+name: NightlyBuild
+
+on:
+  schedule:
+    # This is a UTC time
+    - cron: "0 16 * * *"
+  # Keep it only for test purpose, comment it once everything is ok
+  workflow_dispatch:
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: ks-installer
+  IMAGE_REPO: kubespheredev
+  IMAGE_VERSION: latest
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=$IMAGE_REPO/$IMAGE_NAME
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$IMAGE_VERSION
+          docker push $IMAGE_ID:$IMAGE_VERSION
+          
+          tag=nightly-$(date '+%Y%m%d')
+
+          docker tag $IMAGE_NAME $IMAGE_ID:${tag}
+          docker push $IMAGE_ID:${tag}
+
+      - name: slack
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        if: always()


### PR DESCRIPTION
Please add a secret into GitHub settings with `SLACK_WEBHOOK_URL`. Here is [a tutorial](https://www.chenshaowen.com/blog/using-terraform-and-github-actions-to-test-iac.html#34-%E5%A6%82%E4%BD%95%E7%BB%99-github-actions-%E9%85%8D%E7%BD%AE-slack-%E9%80%9A%E7%9F%A5) about how to add a Slack webhook.

See also https://github.com/kubesphere/console/pull/1386 and https://github.com/kubesphere/kubesphere/pull/3228