### PR TITLE
Uses kubectl apply to create or update crds

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -26,16 +26,16 @@
 
 
 - name: KubeSphere | Create KubeSphere crds
-  shell: "{{ bin_dir }}/kubectl create -R -f {{ kubesphere_dir }}/ks-crds/"
+  shell: "{{ bin_dir }}/kubectl apply -R -f {{ item }}"
   register: import
-  failed_when: "import.stderr and 'AlreadyExists' not in import.stderr"
+  with_fileglob:
+    - "{{ kubesphere_dir }}/ks-crds/*.yaml"
+  failed_when: "import.stderr and 'Warning: kubectl apply' not in import.stderr"
 
-
-- name: KubeSphere | Recreate KubeSphere crds 
-  shell: "{{ bin_dir }}/kubectl create -R -f {{ kubesphere_dir }}/ks-crds/"
+- name: KubeSphere | Create Storage ProvisionerCapability
+  shell: "{{ bin_dir }}/kubectl apply -R -f {{ kubesphere_dir }}/ks-crds/provisonercapability"
   register: import
-  failed_when: "import.stderr and 'AlreadyExists' not in import.stderr"
-
+  failed_when: "import.stderr and 'Warning: kubectl apply' not in import.stderr"
 
 - name: KubeSphere | check k8s version
   shell: >


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

Use `kubectl apply` instead of the `kubectl create`  command to create crds, so crds could be updated accordingly.
**BTW**: It's clear that updates of crds are not recommended, the new version should be added instead. But sometimes we do need some small changes on those crds and without backward compatibility issue. 