### PR TITLE
fix: the ${name} is "" at [scripts/offline-installation-tool.sh]

### DIFF
--- a/scripts/offline-installation-tool.sh
+++ b/scripts/offline-installation-tool.sh
@@ -126,14 +126,14 @@ if [[ ${save} == "true" ]] && [[ -n "${ImagesList}" ]]; then
     index=0
     for image in $(<${ImagesList}); do
         if [[ ${image} =~ ^\#\#.* ]]; then
+           images=""
+           name=$(echo "${image}" | sed 's/#//g' | sed -e 's/[[:space:]]//g')
            if [[ -n ${images} ]]; then
               echo ""
               echo "Save images: "${name}" to "${ImagesDir}"/"${name}".tar.gz  <<<"
               docker save ${images} | gzip -c > ${ImagesDir}"/"${name}.tar.gz
               echo ""
            fi
-           images=""
-           name=$(echo "${image}" | sed 's/#//g' | sed -e 's/[[:space:]]//g')
            ((index++))
            continue
         fi


### PR DESCRIPTION
I found the log: 【Save images:  to ./kubesphere-images/.tar.gz  <<<】when I use command "【./offline-installation-tool.sh -s -l images-list.txt -d ./kubesphere-images】 .
So I look up the script: 【echo "Save images: "${name}" to "${ImagesDir}"/"${name}".tar.gz  <<<"】，${name} is used before it's assigned.