### PR TITLE
fix: modify var [kubesphere_component_pod]

### DIFF
--- a/roles/preinstall/tasks/main.yaml
+++ b/roles/preinstall/tasks/main.yaml
@@ -5,16 +5,16 @@
 - name: Kubesphere | Checking kubesphere component
   shell: >
     {{ bin_dir }}/kubectl get deploy -n kubesphere-system
-  register: kubesphere_component_pod
+  register: kubesphere_component_deployment
 
 - name: Kubesphere | Get kubesphere component version
   shell: >
     {{ bin_dir }}/kubectl get deploy -n  kubesphere-system ks-console -o jsonpath='{.metadata.labels.version}'
   register: console_version
   when:
-    - kubesphere_component_pod.stdout.find("ks-console") != -1
+    - kubesphere_component_deployment.stdout.find("ks-console") != -1
 
 - import_tasks: helm-migrate.yaml
   when: 
-    - kubesphere_component_pod.stdout.find("ks-console") != -1
+    - kubesphere_component_deployment.stdout.find("ks-console") != -1
     - console_version.stdout is version('v3.0.0', '<')


### PR DESCRIPTION
fix: modify kubesphere_component_pod to kubesphere_component_deployment

The result with 【kubectl get deploy -n kubesphere-system】 is a deployment list，so the variable kubesphere_component_deployment is more precise