### PR TITLE
Add local_registry at ClusterConfiguration

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -11,6 +11,7 @@ spec:
     storageClass: ""        # If there is not a default StorageClass in your cluster, you need to specify an existing StorageClass here.
   authentication:
     jwtSecret: ""           # Keep the jwtSecret consistent with the host cluster. Retrive the jwtSecret by executing "kubectl -n kubesphere-system get cm kubesphere-config -o yaml | grep -v "apiVersion" | grep jwtSecret" on the host cluster.
+  local_registry: ""        # Add your private registry address if it is needed.
   etcd:
     monitoring: false       # Whether to enable etcd monitoring dashboard installation. You have to create a secret for etcd before you enable it.
     endpointIps: localhost  # etcd cluster EndpointIps, it can be a bunch of IPs here.


### PR DESCRIPTION
Signed-off-by: daniel-hutao <farmer.hutao@outlook.com>

Deploying ks in the local area network environment is a very common requirement. This parameter(local_registry) has a high usage rate, and it is more appropriate to put it out. In addition, many people have asked if this parameter is still available, can it be used, etc. in the community. so it is more appropriate to put it out.