### PR TITLE
Allows authenticated user access discovery apis

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -105,6 +105,11 @@ metadata:
         input.User.Name == input.Name
       }
       allow = true {
+        allowedNoneResources := ["/api","/api/v1"]
+        allowedNoneResources[_] == input.Path
+        input.Verb == "GET"
+      }
+      allow = true {
         input.APIGroup == "tenant.kubesphere.io"
         input.KubernetesRequest == false
         allowedVerbs := ["get","list","watch"]


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>
Any authenticated user should be allowed to access discovery apis.

/kind bug 
/cc @wansir 