### PR TITLE
fix kubesphere/kubesphere#3297

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -656,6 +656,8 @@ rules:
       - categories
       - apps/audits
       - workloads
+      - groups
+      - groupbindings
     verbs:
       - get
       - list


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

Fixed kubesphere/kubesphere#3297. "Workspace view"  permisison under platform level don't have permission to access groups.

