### PR TITLE
freeze s2i tag

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -153,9 +153,9 @@ builder_go_tag: v2.1.0
 
 #s2i
 s2ioperator_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/s2ioperator"
-s2ioperator_tag: "latest"
+s2ioperator_tag: "v3.1.0"
 s2irun_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/s2irun"
-s2irun_tag: "latest"
+s2irun_tag: "release-2.1"
 
 s2itemplates_tag: v2.1.0
 binary_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/s2i-binary"

--- a/roles/ks-devops/s2i/templates/s2ioperator.yaml.j2
+++ b/roles/ks-devops/s2i/templates/s2ioperator.yaml.j2
@@ -442,7 +442,7 @@ spec:
         - name: S2IIMAGENAME
           value: "{{ s2irun_repo }}:{{ s2irun_tag }}"
         image: "{{ s2ioperator_repo }}:{{ s2ioperator_tag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Signed-off-by: shaowenchen <mail@chenshaowen.com>

S2I depends on these images

- kubespheredev/s2ioperator:v3.1.0
- kubespheredev/s2irun:release-2.1
- s2itemplates images

It needs to be frozen for releasing 3.1.0.

