### PR TITLE
rbac.authorization.k8s.io/v1beta1 is going to removed on v1.22.0

### DIFF
--- a/roles/ks-core/prepare/templates/kubesphere-controls-system.yaml.j2
+++ b/roles/ks-core/prepare/templates/kubesphere-controls-system.yaml.j2
@@ -3,7 +3,7 @@
 # metadata:
 #   name: kubesphere-controls-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:kubesphere-router-clusterrole
@@ -74,7 +74,7 @@ rules:
     verbs:
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: system:kubesphere-router-role
@@ -123,7 +123,7 @@ metadata:
   annotations:
     kubernetes.io/created-by: kubesphere.io/ks-router
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:nginx-ingress-clusterrole-nisa-binding
@@ -138,7 +138,7 @@ subjects:
     name: kubesphere-router-serviceaccount
     namespace: kubesphere-controls-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding
@@ -227,7 +227,7 @@ metadata:
     kubernetes.io/created-by: kubesphere.io/kubectl
 ---
 # bind kubesphere-cluster-admin sa to clusterrole cluster-admin
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:kubesphere-cluster-admin

--- a/roles/kubeedge/files/kubeedge/kubeedge/templates/clusterrole_edge_watcher_metricsreader.yaml
+++ b/roles/kubeedge/files/kubeedge/kubeedge/templates/clusterrole_edge_watcher_metricsreader.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: edge-watcher-metrics-reader


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 was deprecated since k8s 1.17.0 and it will be removed in v1.22.
Need use rbac.authorization.k8s.io/v1 instead.

fix #1422
Signed-off-by: Roland.Ma <rolandma@yunify.com>