### PR TITLE
Fix system-workspace shouldn't be controled by kubefed

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -994,6 +994,8 @@ subjects:
 apiVersion: tenant.kubesphere.io/v1alpha2
 kind: WorkspaceTemplate
 metadata:
+  labels:
+    kubefed.io/managed: "false"
   annotations:
     kubesphere.io/creator: admin
     kubesphere.io/description: "system-workspace is a built-in workspace automatically created by KubeSphere, it contains all system components to run KubeSphere."
@@ -1005,7 +1007,18 @@ spec:
     spec:
       manager: admin
       networkIsolation: false
-
+---
+apiVersion: tenant.kubesphere.io/v1alpha1
+kind: Workspace
+metadata:
+  labels:
+    kubefed.io/managed: "false"
+  annotations:
+    kubesphere.io/creator: admin
+  name: system-workspace
+spec:
+  manager: admin
+  networkIsolation: false
 ---
 apiVersion: iam.kubesphere.io/v1alpha2
 kind: WorkspaceRole


### PR DESCRIPTION
Add  `kubefed.io/managed: "false"` to system-workspace, so it won't be controlled by Federated Workspaces.
1. Added `kubefed.io/managed: "false"` to WorkspaceTemplate, since Workspace resource is a copy of WorkspaceTemplate in a single cluster or initial cluster the first time.
2. Added Workspace to cover upgrade scenario when upgrade member cluster. 

Related: kubesphere/kubesphere#3772