### PR TITLE
Limit the maximum name length

### DIFF
--- a/roles/common/files/ks-crds/iam.kubesphere.io_globalroles.yaml
+++ b/roles/common/files/ks-crds/iam.kubesphere.io_globalroles.yaml
@@ -30,6 +30,10 @@ spec:
             type: string
           metadata:
             type: object
+            properties:
+              name:
+                maxLength: 63
+                type: string
           rules:
             description: Rules holds all the PolicyRules for this GlobalRole
             items:

--- a/roles/common/files/ks-crds/iam.kubesphere.io_groups.yaml
+++ b/roles/common/files/ks-crds/iam.kubesphere.io_groups.yaml
@@ -35,6 +35,10 @@ spec:
             type: string
           metadata:
             type: object
+            properties:
+              name:
+                maxLength: 32
+                type: string
           spec:
             description: GroupSpec defines the desired state of Group
             type: object

--- a/roles/common/files/ks-crds/iam.kubesphere.io_users.yaml
+++ b/roles/common/files/ks-crds/iam.kubesphere.io_users.yaml
@@ -38,6 +38,10 @@ spec:
             type: string
           metadata:
             type: object
+            properties:
+              name:
+                maxLength: 32
+                type: string
           spec:
             description: UserSpec defines the desired state of User
             properties:

--- a/roles/common/files/ks-crds/iam.kubesphere.io_workspaceroles.yaml
+++ b/roles/common/files/ks-crds/iam.kubesphere.io_workspaceroles.yaml
@@ -37,6 +37,10 @@ spec:
             type: string
           metadata:
             type: object
+            properties:
+              name:
+                maxLength: 63
+                type: string
           rules:
             description: Rules holds all the PolicyRules for this WorkspaceRole
             items:


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/3784

Limit the maximum name length, avoid accidentally deleting role bindings.

We use username as the label value when deleting resources in batch, If the [label value is invalid](https://github.com/kubernetes/apimachinery/blob/kubernetes-1.18.6/pkg/util/validation/validation.go#L158-L170), all resources will be deleted accidentally. The length of the username must be limited to ensure that the length of the `UserReferenceLabel` is less than 64.

https://github.com/kubesphere/kubesphere/blob/v3.0.0/pkg/controller/user/user_controller.go#L556-L559
```
	listOptions := metav1.ListOptions{
		LabelSelector: labels.SelectorFromSet(labels.Set{iamv1alpha2.UserReferenceLabel: user.Name}).String(),
	}
```
