### PR TITLE
add RawExtension type annotation

### DIFF
--- a/roles/common/files/ks-crds/iam.kubesphere.io_rolebases.yaml
+++ b/roles/common/files/ks-crds/iam.kubesphere.io_rolebases.yaml
@@ -32,6 +32,8 @@ spec:
             type: object
           role:
             type: object
+            x-kubernetes-embedded-resource: true
+            x-kubernetes-preserve-unknown-fields: true
         required:
         - role
         type: object


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`Role` Filed in `RoleBas`e type was missing when upgrading CustomResourceDefinition from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1.
According to the [Kubernetes doc ](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#rawextension), we need to set the below properties:

```yaml
type: object
properties:
  foo:
    x-kubernetes-embedded-resource: true
    x-kubernetes-preserve-unknown-fields: true
```


**Which issue(s) this PR fixes**:

Fixes kubesphere/kubesphere#3794

/cc @zryfish @wansir 