### PR TITLE
add annotation for workspacetemplate crd

### DIFF
--- a/roles/common/files/ks-crds/tenant.kubesphere.io_workspacetemplates.yaml
+++ b/roles/common/files/ks-crds/tenant.kubesphere.io_workspacetemplates.yaml
@@ -47,6 +47,7 @@ spec:
                             type: string
                           value:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         required:
                         - path
                         type: object


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`RawExtention` Type in WorkspaceTemplate type was missing when upgrading CustomResourceDefinition from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1.
```yaml
type: object
properties:
  foo:
    x-kubernetes-preserve-unknown-fields: true
```


**Which issue(s) this PR fixes**:

Related kubesphere/kubesphere#3794

/cc @zryfish @wansir 