### PR TITLE
Correct patch content for plugin test step in pr-test.yml

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Test plugin
       run: |
-        kubectl -n kubesphere-system patch cc ks-installer --type merge --patch '{"spec":{"alerting":{"enabled":true},"auditing":{"enabled":true},"enableMultiLogin":{"enabled":true},"events":{"enabled":true},"logging":{"enabled":true},"metrics_server":{"enabled":true},"network":{"networkpolicy":{"enabled":true}},"store":{"enabled":true}}}'
+        kubectl -n kubesphere-system patch cc ks-installer --type merge --patch '{"spec":{"alerting":{"enabled":true},"auditing":{"enabled":true},"console":{"enableMultiLogin":true},"events":{"enabled":true},"logging":{"enabled":true},"metrics_server":{"enabled":true},"network":{"networkpolicy":{"enabled":true}},"openpitrix":{"store":{"enabled":true}}}}'
         bash scripts/check_cluster_status.sh
 
     - name: Delete Cluster

--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -41,7 +41,7 @@ spec:
       externalElasticsearchUrl: ""
       externalElasticsearchPort: ""
   console:
-    enableMultiLogin: true  # enable/disable multiple sing on, it allows an account can be used by different users at the same time.
+    enableMultiLogin: true  # enable/disable multiple sign on, it allows an account can be used by different users at the same time.
     port: 30880
   alerting:                # (CPU: 0.1 Core, Memory: 100 MiB) Whether to install KubeSphere alerting system. It enables Users to customize alerting policies to send messages to receivers in time with different time intervals and alerting levels to choose from.
     enabled: false


### PR DESCRIPTION
This pr is trying to fix wrong patch json while testing plugin in pr-test.yml.

Let's have a look at incorrect patch raw json:

https://github.com/kubesphere/ks-installer/blob/dd5274f536bdcb52fa3738dfb196b9169b7a3d72/.github/workflows/pr-test.yml#L39

and incorrect patch formatted json:

```json
{
  "spec": {
    "alerting": { "enabled": true },
    "auditing": { "enabled": true },
    "enableMultiLogin": { "enabled": true },
    "events": { "enabled": true },
    "logging": { "enabled": true },
    "metrics_server": { "enabled": true },
    "network": { "networkpolicy": { "enabled": true } },
    "store": { "enabled": true }
  }
}
```

I've already convert the json format into yaml format:

```yaml
spec:
  alerting:
    enabled: true
  auditing:
    enabled: true
  events:
    enabled: true
  logging:
    enabled: true
  metrics_server:
    enabled: true
  network:
    networkpolicy:
      enabled: true
  openpitrix:
    store:
      enabled: true
```

Related to #1454

BTW, this PR is no hurry to merge.

/kind bug