### PR TITLE
Change the docker hub org of devops from kubespheredev to kubesphere

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -141,24 +141,24 @@ snapshot_controller_repo: "{{ base_repo }}{{ namespace_override | default('csipl
 snapshot_controller_tag: "v2.0.1"
 
 #jenkins:
-jenkins_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/ks-jenkins"
+jenkins_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-jenkins"
 jenkins_tag: 2.249.1
 jnlp_slave_repo: "{{ base_repo }}{{ namespace_override | default('jenkins') }}/jnlp-slave"
 jnlp_slave_tag: 3.27-1
 builder_base_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/builder-base"
-builder_base_tag: v2.1.0
+builder_base_tag: v3.1.0
 builder_nodejs_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/builder-nodejs"
-builder_nodejs_tag: v2.1.0
+builder_nodejs_tag: v3.1.0
 builder_maven_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/builder-maven"
-builder_maven_tag: v2.1.0
+builder_maven_tag: v3.1.0
 builder_go_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/builder-go"
-builder_go_tag: v2.1.0
+builder_go_tag: v3.1.0
 
 #s2i
-s2ioperator_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/s2ioperator"
+s2ioperator_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/s2ioperator"
 s2ioperator_tag: "v3.1.0"
-s2irun_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/s2irun"
-s2irun_tag: "release-2.1"
+s2irun_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/s2irun"
+s2irun_tag: "v2.1.1"
 
 s2itemplates_tag: v2.1.0
 binary_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/s2i-binary"


### PR DESCRIPTION
Before merge this please don't forget push image `kubespheredev/s2irun:release-2.1` to `kubesphere/s2irun:release-2.1`

* [ ] `kubespheredev/s2irun:release-2.1` -> `kubesphere/s2irun:v2.1.1`
* [ ] `kubespheredev/builder-base:v3.1.0` -> `kubesphere/builder-base:v3.1.0`
* [ ] `kubespheredev/builder-nodejs:v3.1.0` -> `kubesphere/builder-nodejs:v3.1.0`
* [ ] `kubespheredev/builder-maven:v3.1.0` -> `kubesphere/builder-maven:v3.1.0`
* [ ] `kubespheredev/builder-go:v3.1.0` -> `kubesphere/builder-go:v3.1.0`