### PR TITLE
Add tool for build an all-in-one images registry

### DIFF
--- a/.github/workflows/build-images-registry.yml
+++ b/.github/workflows/build-images-registry.yml
@@ -1,0 +1,59 @@
+---
+name: Build all-in-one images registry
+
+on:
+  push:
+    branches: [master, express]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "0 16 * * *"
+
+env:
+  IMAGE_REPO: "kubespheredev"
+  IMAGE_NAME: "images-registry"
+  IMAGE_TAG: "latest"
+  SKOPEO_VERSION: v1.2.0
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Extend free disk
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+
+      - name: Run docker registry
+        run: |
+          sudo docker run -d --name registry -v /var/lib/registry:/var/lib/registry -p 127.0.0.1:80:5000 registry:2
+
+      - name: Sync all images
+        shell: bash
+        run: |
+          bash scripts/sync-images.sh scripts/images-list.txt docker.io localhost
+
+      - name: Build skopeo binary
+        shell: bash
+        run: |
+          docker build -t skopeo:${SKOPEO_VERSION} -f scripts/build/Dockerfile.skopeo .
+          docker run -d --name skopeo skopeo:${SKOPEO_VERSION} sleep 60s
+          docker cp skopeo:/usr/bin/skopeo .
+
+      - name: Build images registry
+        shell: bash
+        run: |
+          sudo docker stop registry
+          sudo mv -f /var/lib/registry/docker .
+          sudo docker build -t ${IMAGE_REPO}/${IMAGE_NAME}:${IMAGE_TAG} -f scripts/build/Dockerfile.registry .
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push image
+        run: |
+          docker push ${IMAGE_REPO}/${IMAGE_NAME}:${IMAGE_TAG}

--- a/scripts/build/Dockerfile.registry
+++ b/scripts/build/Dockerfile.registry
@@ -1,0 +1,18 @@
+FROM registry:2 as base
+FROM debian:buster-slim
+
+RUN apt update -y \
+    && apt install -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=base /bin/registry /bin/registry
+COPY --from=base /etc/docker/registry/config.yml /etc/docker/registry/config.yml
+COPY docker /var/lib/registry/docker
+
+WORKDIR /root
+COPY skopeo /usr/bin
+COPY scripts/sync-images.sh sync.sh
+COPY scripts/images-list.txt images-list.txt
+EXPOSE 5000
+ENTRYPOINT ["registry"]
+CMD ["serve", "/etc/docker/registry/config.yml"]

--- a/scripts/build/Dockerfile.skopeo
+++ b/scripts/build/Dockerfile.skopeo
@@ -1,0 +1,11 @@
+FROM golang:1.14-buster as builder
+ARG SKOPEO_VERSION=v1.2.0
+RUN apt-get update && \
+    apt-get install -y \
+        libdevmapper-dev \
+        libgpgme11-dev 
+
+ENV GOPATH=/
+WORKDIR /src/github.com/containers/skopeo
+RUN git clone --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /src/github.com/containers/skopeo && \
+    CGO_ENABLE=0 GO111MODULE=on go build -mod=vendor "-buildmode=pie" -ldflags '-extldflags "-static"' -gcflags "" -tags "exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" -o /usr/bin/skopeo ./cmd/skopeo

--- a/scripts/sync-images.sh
+++ b/scripts/sync-images.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+GREEN_COL="\\033[32;1m"
+RED_COL="\\033[1;31m"
+YELLOW_COL="\\033[33;1m"
+NORMAL_COL="\\033[0;39m"
+
+IMAGES_LIST=$1
+SOURCE_REGISTRY=$2
+TARGET_REGISTRY=$3
+: ${IMAGES_LIST:="images-list.txt"}
+: ${TARGET_REGISTRY:="localhost"}
+: ${SOURCE_REGISTRY:="docker.io"}
+
+set -eo pipefail
+
+skopeo_copy() {
+    if skopeo copy --insecure-policy --src-tls-verify=false --dest-tls-verify=false -q docker://$1 docker://$2; then
+        echo -e "$GREEN_COL Progress: ${CURRENT_NUM}/${TOTAL_NUMS} sync $1 successful $NORMAL_COL"
+    else
+        echo -e "$RED_COL Sync $1 failed $NORMAL_CO"
+    fi
+}
+
+CURRENT_NUM=0
+TOTAL_NUMS=$(sed -n '/#/d;s/:/:/p' ${IMAGES_LIST} | wc -l)
+for image in $(sed -n '/#/d;s/:/:/p' ${IMAGES_LIST}); do
+    let CURRENT_NUM=${CURRENT_NUM}+1
+    skopeo_copy ${SOURCE_REGISTRY}/${image} ${TARGET_REGISTRY}/${image}
+done


### PR DESCRIPTION
Signed-off-by: muzi502 muzi502.li@gmail.com

 Add tool to build an all-in-one images registry for offline deploy and bypass dockerhub 429 toomany requests error.

For offline deploy user, can docker pull this image and run a registry container, then user this registry to deploy kubesphere or sync all image to his private registry.

like this:

1. run an all-in-one images registry

```shell
$ docker run -d --net=host --name kube-registry -e REGISTRY_HTTP_ADDR=0.0.0.0:5001 images-registry:latest
```

2. sync all images to his private docker registry

> localhost:5000 is target docker registry

```shell
$ docker exec -it kube-registry bash /root/sync.sh /root/images-list.txt localhost:5001 localhost:5000
```
 - output

```shell
Progress: 1/137 sync localhost:5001/kubesphere/kube-apiserver:v1.20.4 successful
 Progress: 2/137 sync localhost:5001/kubesphere/kube-scheduler:v1.20.4 successful
 Progress: 3/137 sync localhost:5001/kubesphere/kube-proxy:v1.20.4 successful
 Progress: 4/137 sync localhost:5001/kubesphere/kube-controller-manager:v1.20.4 successful
 Progress: 5/137 sync localhost:5001/kubesphere/kube-apiserver:v1.19.8 successful
 Progress: 6/137 sync localhost:5001/kubesphere/kube-scheduler:v1.19.8 successful
 Progress: 7/137 sync localhost:5001/kubesphere/kube-proxy:v1.19.8 successful
 Progress: 8/137 sync localhost:5001/kubesphere/kube-controller-manager:v1.19.8 successful
 Progress: 9/137 sync localhost:5001/kubesphere/kube-apiserver:v1.18.6 successful
 Progress: 10/137 sync localhost:5001/kubesphere/kube-scheduler:v1.18.6 successful
 Progress: 11/137 sync localhost:5001/kubesphere/kube-proxy:v1.18.6 successful
 Progress: 12/137 sync localhost:5001/kubesphere/kube-controller-manager:v1.18.6 successful
 Progress: 13/137 sync localhost:5001/kubesphere/kube-apiserver:v1.17.9 successful
 Progress: 14/137 sync localhost:5001/kubesphere/kube-scheduler:v1.17.9 successful
 Progress: 15/137 sync localhost:5001/kubesphere/kube-proxy:v1.17.9 successful
 Progress: 16/137 sync localhost:5001/kubesphere/kube-controller-manager:v1.17.9 successful
 Progress: 17/137 sync localhost:5001/kubesphere/pause:3.1 successful
 Progress: 18/137 sync localhost:5001/kubesphere/pause:3.2 successful
 Progress: 19/137 sync localhost:5001/kubesphere/etcd:v3.4.13 successful
 Progress: 20/137 sync localhost:5001/calico/cni:v3.16.3 successful
 Progress: 21/137 sync localhost:5001/calico/kube-controllers:v3.16.3 successful
 Progress: 22/137 sync localhost:5001/calico/node:v3.16.3 successful
 Progress: 23/137 sync localhost:5001/calico/pod2daemon-flexvol:v3.16.3 successful
 Progress: 24/137 sync localhost:5001/coredns/coredns:1.6.9 successful
 Progress: 25/137 sync localhost:5001/kubesphere/k8s-dns-node-cache:1.15.12 successful
 Progress: 26/137 sync localhost:5001/openebs/provisioner-localpv:2.3.0 successful
 Progress: 27/137 sync localhost:5001/openebs/linux-utils:2.3.0 successful
 Progress: 28/137 sync localhost:5001/kubesphere/nfs-client-provisioner:v3.1.0-k8s1.11 successful
 Progress: 29/137 sync localhost:5001/csiplugin/csi-neonsan:v1.2.0 successful
 Progress: 30/137 sync localhost:5001/csiplugin/csi-neonsan-ubuntu:v1.2.0 successful
 Progress: 31/137 sync localhost:5001/csiplugin/csi-neonsan-centos:v1.2.0 successful
 Progress: 32/137 sync localhost:5001/csiplugin/csi-provisioner:v1.5.0 successful
 Progress: 33/137 sync localhost:5001/csiplugin/csi-attacher:v2.1.1 successful
 Progress: 34/137 sync localhost:5001/csiplugin/csi-resizer:v0.4.0 successful
 Progress: 35/137 sync localhost:5001/csiplugin/csi-snapshotter:v2.0.1 successful
 Progress: 36/137 sync localhost:5001/csiplugin/csi-node-driver-registrar:v1.2.0 successful
 Progress: 37/137 sync localhost:5001/csiplugin/csi-qingcloud:v1.2.0 successful
 Progress: 38/137 sync localhost:5001/kubesphere/ks-apiserver:v3.1.0 successful
 Progress: 39/137 sync localhost:5001/kubesphere/ks-console:v3.1.0 successful
 Progress: 40/137 sync localhost:5001/kubesphere/ks-controller-manager:v3.1.0 successful
 Progress: 41/137 sync localhost:5001/kubesphere/ks-installer:v3.1.0 successful
 Progress: 42/137 sync localhost:5001/kubesphere/kubectl:v1.19.0 successful
 Progress: 43/137 sync localhost:5001/redis:5.0.5-alpine successful
 Progress: 44/137 sync localhost:5001/alpine:3.10.4 successful
 Progress: 45/137 sync localhost:5001/haproxy:2.0.4 successful
 Progress: 46/137 sync localhost:5001/nginx:1.14-alpine successful
 Progress: 47/137 sync localhost:5001/minio/minio:RELEASE.2019-08-07T01-59-21Z successful
 Progress: 48/137 sync localhost:5001/minio/mc:RELEASE.2019-08-07T23-14-43Z successful
 Progress: 49/137 sync localhost:5001/mirrorgooglecontainers/defaultbackend-amd64:1.4 successful
 Progress: 50/137 sync localhost:5001/kubesphere/nginx-ingress-controller:v0.35.0 successful
 Progress: 51/137 sync localhost:5001/osixia/openldap:1.3.0 successful
 Progress: 52/137 sync localhost:5001/csiplugin/snapshot-controller:v2.0.1 successful
 Progress: 53/137 sync localhost:5001/kubesphere/kubefed:v0.7.0 successful
 Progress: 54/137 sync localhost:5001/kubesphere/tower:v0.2.0 successful
 Progress: 55/137 sync localhost:5001/kubesphere/prometheus-config-reloader:v0.42.1 successful
 Progress: 56/137 sync localhost:5001/kubesphere/prometheus-operator:v0.42.1 successful
 Progress: 57/137 sync localhost:5001/prom/alertmanager:v0.21.0 successful
 Progress: 58/137 sync localhost:5001/prom/prometheus:v2.26.0 successful
 Progress: 59/137 sync localhost:5001/prom/node-exporter:v0.18.1 successful
 Progress: 60/137 sync localhost:5001/kubesphere/ks-alerting-migration:v3.1.0 successful
 Progress: 61/137 sync localhost:5001/jimmidyson/configmap-reload:v0.3.0 successful
 Progress: 62/137 sync localhost:5001/kubesphere/notification-manager-operator:v1.0.0 successful
 Progress: 63/137 sync localhost:5001/kubesphere/notification-manager:v1.0.0 successful
 Progress: 64/137 sync localhost:5001/kubesphere/metrics-server:v0.4.2 successful
 Progress: 65/137 sync localhost:5001/kubesphere/kube-rbac-proxy:v0.8.0 successful
 Progress: 66/137 sync localhost:5001/kubesphere/kube-state-metrics:v1.9.7 successful
 Progress: 67/137 sync localhost:5001/openebs/provisioner-localpv:2.3.0 successful
 Progress: 68/137 sync localhost:5001/thanosio/thanos:v0.18.0 successful
 Progress: 69/137 sync localhost:5001/grafana/grafana:7.4.3 successful
 Progress: 70/137 sync localhost:5001/kubesphere/elasticsearch-oss:6.7.0-1 successful
 Progress: 71/137 sync localhost:5001/kubesphere/elasticsearch-curator:v5.7.6 successful
 Progress: 72/137 sync localhost:5001/kubesphere/fluentbit-operator:v0.5.0 successful
 Progress: 73/137 sync localhost:5001/kubesphere/fluentbit-operator:migrator successful
 Progress: 74/137 sync localhost:5001/kubesphere/fluent-bit:v1.6.9 successful
 Progress: 75/137 sync localhost:5001/elastic/filebeat:6.7.0 successful
 Progress: 76/137 sync localhost:5001/kubesphere/kube-auditing-operator:v0.1.2 successful
 Progress: 77/137 sync localhost:5001/kubesphere/kube-auditing-webhook:v0.1.2 successful
 Progress: 78/137 sync localhost:5001/kubesphere/kube-events-exporter:v0.1.0 successful
 Progress: 79/137 sync localhost:5001/kubesphere/kube-events-operator:v0.1.0 successful
 Progress: 80/137 sync localhost:5001/kubesphere/kube-events-ruler:v0.2.0 successful
 Progress: 81/137 sync localhost:5001/kubesphere/log-sidecar-injector:1.1 successful
 Progress: 82/137 sync localhost:5001/docker:19.03 successful
 Progress: 83/137 sync localhost:5001/istio/pilot:1.6.10 successful
 Progress: 84/137 sync localhost:5001/istio/proxyv2:1.6.10 successful
 Progress: 85/137 sync localhost:5001/jaegertracing/jaeger-agent:1.17 successful
 Progress: 86/137 sync localhost:5001/jaegertracing/jaeger-collector:1.17 successful
 Progress: 87/137 sync localhost:5001/jaegertracing/jaeger-es-index-cleaner:1.17 successful
 Progress: 88/137 sync localhost:5001/jaegertracing/jaeger-operator:1.17.1 successful
 Progress: 89/137 sync localhost:5001/jaegertracing/jaeger-query:1.17 successful
 Progress: 90/137 sync localhost:5001/kubesphere/kiali:v1.26.1 successful
 Progress: 91/137 sync localhost:5001/kubesphere/kiali-operator:v1.26.1 successful
 Progress: 92/137 sync localhost:5001/kubesphere/ks-jenkins:2.249.1 successful
 Progress: 93/137 sync localhost:5001/jenkins/jnlp-slave:3.27-1 successful
 Progress: 94/137 sync localhost:5001/kubesphere/s2ioperator:v3.1.0 successful
 Progress: 95/137 sync localhost:5001/kubesphere/s2irun:v2.1.1 successful
 Progress: 96/137 sync localhost:5001/kubesphere/builder-base:v2.1.0 successful
 Progress: 97/137 sync localhost:5001/kubesphere/builder-nodejs:v2.1.0 successful
 Progress: 98/137 sync localhost:5001/kubesphere/builder-maven:v2.1.0 successful
 Progress: 99/137 sync localhost:5001/kubesphere/builder-go:v2.1.0 successful
 Progress: 100/137 sync localhost:5001/kubesphere/s2i-binary:v2.1.0 successful
 Progress: 101/137 sync localhost:5001/kubesphere/tomcat85-java11-centos7:v2.1.0 successful
 Progress: 102/137 sync localhost:5001/kubesphere/tomcat85-java11-runtime:v2.1.0 successful
 Progress: 103/137 sync localhost:5001/kubesphere/tomcat85-java8-centos7:v2.1.0 successful
 Progress: 104/137 sync localhost:5001/kubesphere/tomcat85-java8-runtime:v2.1.0 successful
 Progress: 105/137 sync localhost:5001/kubesphere/java-11-centos7:v2.1.0 successful
 Progress: 106/137 sync localhost:5001/kubesphere/java-8-centos7:v2.1.0 successful
 Progress: 107/137 sync localhost:5001/kubesphere/java-8-runtime:v2.1.0 successful
 Progress: 108/137 sync localhost:5001/kubesphere/java-11-runtime:v2.1.0 successful
 Progress: 109/137 sync localhost:5001/kubesphere/nodejs-8-centos7:v2.1.0 successful
 Progress: 110/137 sync localhost:5001/kubesphere/nodejs-6-centos7:v2.1.0 successful
 Progress: 111/137 sync localhost:5001/kubesphere/nodejs-4-centos7:v2.1.0 successful
 Progress: 112/137 sync localhost:5001/kubesphere/python-36-centos7:v2.1.0 successful
 Progress: 113/137 sync localhost:5001/kubesphere/python-35-centos7:v2.1.0 successful
 Progress: 114/137 sync localhost:5001/kubesphere/python-34-centos7:v2.1.0 successful
 Progress: 115/137 sync localhost:5001/kubesphere/python-27-centos7:v2.1.0 successful
 Progress: 116/137 sync localhost:5001/kubesphere/notification:flyway_v2.1.2 successful
 Progress: 117/137 sync localhost:5001/kubesphere/notification:v2.1.2 successful
 Progress: 118/137 sync localhost:5001/kubesphere/openpitrix-jobs:v3.1.0 successful
 Progress: 119/137 sync localhost:5001/weaveworks/scope:1.13.0 successful
 Progress: 120/137 sync localhost:5001/kubeedge/cloudcore:v1.6.1 successful
 Progress: 121/137 sync localhost:5001/kubesphere/edge-watcher:v0.1.0 successful
 Progress: 122/137 sync localhost:5001/kubesphere/kube-rbac-proxy:v0.5.0 successful
 Progress: 123/137 sync localhost:5001/kubesphere/edge-watcher-agent:v0.1.0 successful
 Progress: 124/137 sync localhost:5001/kubesphere/examples-bookinfo-productpage-v1:1.16.2 successful
 Progress: 125/137 sync localhost:5001/kubesphere/examples-bookinfo-reviews-v1:1.16.2 successful
 Progress: 126/137 sync localhost:5001/kubesphere/examples-bookinfo-reviews-v2:1.16.2 successful
FATA[0000] Error initializing source docker://localhost:5001/kubesphere/examples-bookinfo-reviews-v3:1.16.2: Error reading manifest 1.16.2 in localhost:5001/kubesphere/examples-bookinfo-reviews-v3: manifest unknown: manifest unknown
 Sync localhost:5001/kubesphere/examples-bookinfo-reviews-v3:1.16.2 failed
 Progress: 128/137 sync localhost:5001/kubesphere/examples-bookinfo-details-v1:1.16.2 successful
 Progress: 129/137 sync localhost:5001/kubesphere/examples-bookinfo-ratings-v1:1.16.3 successful
 Progress: 130/137 sync localhost:5001/busybox:1.31.1 successful
 Progress: 131/137 sync localhost:5001/joosthofman/wget:1.0 successful
 Progress: 132/137 sync localhost:5001/kubesphere/netshoot:v1.0 successful
 Progress: 133/137 sync localhost:5001/nginxdemos/hello:plain-text successful
 Progress: 134/137 sync localhost:5001/wordpress:4.8-apache successful
 Progress: 135/137 sync localhost:5001/mirrorgooglecontainers/hpa-example:latest successful
 Progress: 136/137 sync localhost:5001/java:openjdk-8-jre-alpine successful
 Progress: 137/137 sync localhost:5001/fluent/fluentd:v1.4.2-2.0 successful
 Progress: 138/137 sync localhost:5001/perl:latest successful
```

TODO:
docs

/cc @yangchuansheng 