### PR TITLE
Allow to debug ks-installer locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+results

--- a/controller/installRunner.py
+++ b/controller/installRunner.py
@@ -390,7 +390,7 @@ def resultInfo(resultState=False, api=None):
             exit()
 
     if not resultState:
-        with open('/kubesphere/playbooks/kubesphere_running', 'r') as f:
+        with open(os.path.join(playbookBasePath,'kubesphere_running'), 'r') as f:
             info = f.read()
             logging.info(info)
 
@@ -527,20 +527,31 @@ def generate_new_cluster_configuration(api):
 
 
 def main():
-    if not os.path.exists(privateDataDir):
-        os.makedirs(privateDataDir)
+    global privateDataDir, playbookBasePath, configFile, statusFile
 
     if len(sys.argv) > 1 and sys.argv[1] == "--config":
         print(ks_hook)
+        return
+    
+    if len(sys.argv) > 1 and sys.argv[1] == "--debug": 
+        privateDataDir = os.path.abspath('./results')
+        playbookBasePath = os.path.abspath('./playbooks')
+        configFile = os.path.abspath('./results/ks-config.json')
+        statusFile = os.path.abspath('./results/ks-status.json')
+        config.load_kube_config()
     else:
         config.load_incluster_config()
-        api = client.CustomObjectsApi()
-        generate_new_cluster_configuration(api)
-        generateConfig(api)
-        # execute preInstall tasks
-        preInstallTasks()
-        resultState = getResultInfo()
-        resultInfo(resultState, api)
+
+    if not os.path.exists(privateDataDir):
+        os.makedirs(privateDataDir)
+
+    api = client.CustomObjectsApi()
+    generate_new_cluster_configuration(api)
+    generateConfig(api)
+    # execute preInstall tasks
+    preInstallTasks()
+    resultState = getResultInfo()
+    resultInfo(resultState, api)
 
 
 if __name__ == '__main__':

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -46,3 +46,45 @@
     |-- README.md
 ```
 
+## Debug ks-installer locally
+
+> tips: This guide only works on Linux & Mac
+
+> Prerequisite: helm v3.2.x, kubectl v1.19.x are needed.
+
+1. Prepare local working directory
+Once you have cloned ks-installer repo in your working directory. Enter the `ks-installer` folder first. You need to create a `results` folder and copy the `env` folder to the `results` folder, which will be used by Ansible for setting variables and collecting logs.
+
+```bash
+ mkdir results && cp -r ./env/ ./results/
+
+echo "-e @$PWD/results/ks-config.json -e @$PWD/results/ks-status.json" > results/env/cmdline
+```
+
+2. Install Python & required packages
+
+Python3 and pip3 are needed to be installed on your machine. For Ubuntu 18.04 user, you can run the following command:
+
+```bash
+pip3 install psutil cryptography==3.0 ansible_runner==1.4.6 ansible==2.8.12 redis kubernetes
+```
+
+3. Create ClusterConfiguration
+
+The python program still needs to read the ks-installer ClusterConfiguraiton from k8s. So you have to create the CRD. Scaled the ks-installer deployment to 0 replicas, so it won't execute automatically.
+
+```bash
+kubectl apply -f deploy/kubesphere-installer.yaml
+
+kubectl -n kubesphere-system scale deployment ks-installer --replicas=0
+
+kubectl apply -f deploy/cluster-configuration.yaml
+```
+
+4. Launch ks-installer
+
+```bash
+export ANSIBLE_ROLES_PATH=$PWD/roles
+python3 controller/installRunner.py --debug
+```
+


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

/kind feature

Currently, we can only run the ks-installer inside in container. Troubleshooting is difficult during development. So it better to be able to run ks-installer from the working directory.

Added "--debug" flag to installRunner.py. Which will load the playbook from the working directory.