### PR TITLE
upgrade kubeedge version to v1.6.2

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -121,7 +121,7 @@ post_install_job_tag: "v1.19.0"
 
 # kubeedge
 cloudcore_repo: "{{ base_repo }}{{ namespace_override | default('kubeedge') }}/cloudcore"
-cloudcore_tag: "v1.6.1"
+cloudcore_tag: "v1.6.2"
 edge_watcher_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/edge-watcher"
 edge_watcher_tag: "v0.1.0"
 edge_watcher_agent_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/edge-watcher-agent"

--- a/roles/kubeedge/files/kubeedge/kubeedge/values.yaml
+++ b/roles/kubeedge/files/kubeedge/kubeedge/values.yaml
@@ -4,8 +4,8 @@
 appVersion: "0.1.0"
 
 cloudCore:
-  repository: "kubeedge/cloudcore"
-  tag: "v1.6.1"
+  repository: "kubespheredev/cloudcore"
+  tag: "v1.6.2"
   pullPolicy: "IfNotPresent"
   affinity:
     nodeAffinity:

--- a/scripts/images-list.txt
+++ b/scripts/images-list.txt
@@ -128,7 +128,7 @@ kubesphere/openpitrix-jobs:v3.1.0
 ##weave-scope-images
 weaveworks/scope:1.13.0
 ##kubeedge-images
-kubeedge/cloudcore:v1.6.1
+kubespheredev/cloudcore:v1.6.2
 kubesphere/edge-watcher:v0.1.0
 kubesphere/kube-rbac-proxy:v0.5.0
 kubesphere/edge-watcher-agent:v0.1.0


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

> Note: Currently, the kubeedge official have not pushed kubeedge/cloudcore:v1.6.2, we can use the docker image kubespheredev/cloudcore:v1.6.2 instead. 

/kind feature

/cc @benjaminhuo @pixiake 