### PR TITLE
support external prometheus stack

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -26,6 +26,7 @@ spec:
     openldapVolumeSize: 2Gi   # openldap PVC size.
     redisVolumSize: 2Gi # Redis PVC size.
     monitoring:
+      # type: external   # Whether to specify the external prometheus stack, and need to modify the endpoint at the next line.
       endpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090 # Prometheus endpoint to get metrics data.
     es:   # Storage backend for logging, events and auditing.
       # elasticsearchMasterReplicas: 1   # The total number of master nodes. Even numbers are not allowed.

--- a/roles/ks-monitor/tasks/main.yaml
+++ b/roles/ks-monitor/tasks/main.yaml
@@ -1,45 +1,6 @@
----
-- import_tasks: cleanup.yaml
-
-- import_tasks: generate_manifests.yaml
-
-- import_tasks: prometheus-operator.yaml
+- import_tasks: prometheus-stack.yaml
   when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: node-exporter.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: kube-state-metrics.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-# - import_tasks: prometheus-adapter.yaml
-
-- import_tasks: grafana.yaml
-  when:
-    - monitoring.grafana is defined
-    - monitoring.grafana.enabled is defined
-    - monitoring.grafana.enabled == true
-
-- import_tasks: prometheus.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: devops.yaml
-
-- import_tasks: etcd.yaml
-
-- import_tasks: prometheus-rules.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: alertmanager.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: notification-manager.yaml
+    - "common.monitoring.type is not defined or common.monitoring.type != 'external'"
 
 - import_tasks: monitoring-dashboard.yaml
   when:

--- a/roles/ks-monitor/tasks/prometheus-stack.yaml
+++ b/roles/ks-monitor/tasks/prometheus-stack.yaml
@@ -1,0 +1,46 @@
+---
+- import_tasks: cleanup.yaml
+
+- import_tasks: generate_manifests.yaml
+
+- import_tasks: prometheus-operator.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: node-exporter.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: kube-state-metrics.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+# - import_tasks: prometheus-adapter.yaml
+
+- import_tasks: grafana.yaml
+  when:
+    - monitoring.grafana is defined
+    - monitoring.grafana.enabled is defined
+    - monitoring.grafana.enabled == true
+
+- import_tasks: prometheus.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: devops.yaml
+
+- import_tasks: etcd.yaml
+
+- import_tasks: prometheus-rules.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: alertmanager.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: notification-manager.yaml
+
+- import_tasks: monitoring-dashboard.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

support external prometheus stack, fix #1503
- split current main.yaml, move kubesphere prometheus stack outside to prometheus-stack.yaml.
- add condition to activate the kubesphere prometheus stack.


/kind feature

/cc @benjaminhuo