### PR TITLE
Add preset CSI Provisioner CRs and remove mountpath of kubelet plugins

### DIFF
--- a/roles/common/files/ks-crds/provisonercapability/disk-csi-qingcloud-com.yaml
+++ b/roles/common/files/ks-crds/provisonercapability/disk-csi-qingcloud-com.yaml
@@ -1,0 +1,20 @@
+apiVersion: storage.kubesphere.io/v1alpha1
+kind: ProvisionerCapability
+metadata:
+  name: disk-csi-qingcloud-com
+spec:
+  pluginInfo:
+    name: disk.csi.qingcloud.com
+    version: ""
+  features:
+    topology: true
+    snapshot:
+      create: true
+      list: false
+    volume:
+      attach: true
+      clone: true
+      create: true
+      expandMode: OFFLINE
+      list: false
+      stats: true

--- a/roles/common/files/ks-crds/provisonercapability/neonsan-csi-qingstor-com.yaml
+++ b/roles/common/files/ks-crds/provisonercapability/neonsan-csi-qingstor-com.yaml
@@ -1,0 +1,20 @@
+apiVersion: storage.kubesphere.io/v1alpha1
+kind: ProvisionerCapability
+metadata:
+  name: neonsan-csi-qingstor-com
+spec:
+  pluginInfo:
+    name: neonsan.csi.qingstor.com
+    version: ""
+  features:
+    topology: false
+    snapshot:
+      create: true
+      list: false
+    volume:
+      attach: true
+      clone: true
+      create: true
+      expandMode: OFFLINE
+      list: false
+      stats: true

--- a/roles/ks-core/ks-core/templates/ks-controller-manager.yaml.j2
+++ b/roles/ks-core/ks-core/templates/ks-controller-manager.yaml.j2
@@ -56,8 +56,6 @@ spec:
           name: kubesphere-config
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-secret
-        - mountPath: /var/lib/kubelet/plugins/
-          name: kubelet-plugin
         - mountPath: /etc/localtime
           name: host-time
       dnsPolicy: ClusterFirst
@@ -75,10 +73,6 @@ spec:
           secret:
             defaultMode: 420
             secretName: ks-controller-manager-webhook-cert
-        - name: kubelet-plugin
-          hostPath:
-            path: /var/lib/kubelet/plugins/
-            type: DirectoryOrCreate
         - hostPath:
             path: /etc/localtime
             type: ""


### PR DESCRIPTION
Signed-off-by: dkven <dkvvven@gmail.com>

This is a corresponding PR with [this PR](https://github.com/kubesphere/kubesphere/pull/3947) of Kubesphere.

After removing the auto detection of StorageClassCapabilities, we need a preset ProvisionerCapability CR for each of qingcloud-csi and qingstor-csi.

And the `/var/lib/kubelet/plugins/` hostpath volume is no longer needed.