### PR TITLE
tweak etcd selector for etcdHighNumberOfFailedGRPCRequests rule

### DIFF
--- a/roles/ks-monitor/files/prometheus/etcd/prometheus-rulesEtcd.yaml
+++ b/roles/ks-monitor/files/prometheus/etcd/prometheus-rulesEtcd.yaml
@@ -140,9 +140,9 @@ spec:
         message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for
           {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
       expr: |
-        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
+        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK",grpc_service!="etcdserverpb.Watch"}[5m])) BY (job, instance, grpc_service, grpc_method)
           /
-        sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
+        sum(rate(grpc_server_handled_total{job=~".*etcd.*",grpc_service!="etcdserverpb.Watch"}[5m])) BY (job, instance, grpc_service, grpc_method)
           > 1
       for: 10m
       labels:
@@ -152,9 +152,9 @@ spec:
         message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for
           {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
       expr: |
-        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
+        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK",grpc_service!="etcdserverpb.Watch"}[5m])) BY (job, instance, grpc_service, grpc_method)
           /
-        sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
+        sum(rate(grpc_server_handled_total{job=~".*etcd.*",grpc_service!="etcdserverpb.Watch"}[5m])) BY (job, instance, grpc_service, grpc_method)
           > 5
       for: 5m
       labels:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

It workarounds frequent alerts with message `etcd cluster "etcd": 100% of requests for Watch failed on etcd instance...` for `etcdHighNumberOfFailedGRPCRequests` rule , which should be because etcd generates incorrect metrics (this pr https://github.com/etcd-io/etcd/pull/12196 has tried to fix it but it still exists after verification with the version after the pr)

/assign @benjaminhuo @pixiake 