### PR TITLE
[release-3.1] combine some feature fixes by cherry-pick

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -26,6 +26,7 @@ spec:
     openldapVolumeSize: 2Gi   # openldap PVC size.
     redisVolumSize: 2Gi # Redis PVC size.
     monitoring:
+      # type: external   # Whether to specify the external prometheus stack, and need to modify the endpoint at the next line.
       endpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090 # Prometheus endpoint to get metrics data.
     es:   # Storage backend for logging, events and auditing.
       # elasticsearchMasterReplicas: 1   # The total number of master nodes. Even numbers are not allowed.

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -121,7 +121,7 @@ post_install_job_tag: "v1.19.0"
 
 # kubeedge
 cloudcore_repo: "{{ base_repo }}{{ namespace_override | default('kubeedge') }}/cloudcore"
-cloudcore_tag: "v1.6.1"
+cloudcore_tag: "v1.6.2"
 edge_watcher_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/edge-watcher"
 edge_watcher_tag: "v0.1.0"
 edge_watcher_agent_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/edge-watcher-agent"

--- a/roles/ks-monitor/tasks/main.yaml
+++ b/roles/ks-monitor/tasks/main.yaml
@@ -1,45 +1,6 @@
----
-- import_tasks: cleanup.yaml
-
-- import_tasks: generate_manifests.yaml
-
-- import_tasks: prometheus-operator.yaml
+- import_tasks: prometheus-stack.yaml
   when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: node-exporter.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: kube-state-metrics.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-# - import_tasks: prometheus-adapter.yaml
-
-- import_tasks: grafana.yaml
-  when:
-    - monitoring.grafana is defined
-    - monitoring.grafana.enabled is defined
-    - monitoring.grafana.enabled == true
-
-- import_tasks: prometheus.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: devops.yaml
-
-- import_tasks: etcd.yaml
-
-- import_tasks: prometheus-rules.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: alertmanager.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: notification-manager.yaml
+    - "common.monitoring.type is not defined or common.monitoring.type != 'external'"
 
 - import_tasks: monitoring-dashboard.yaml
   when:

--- a/roles/ks-monitor/tasks/prometheus-stack.yaml
+++ b/roles/ks-monitor/tasks/prometheus-stack.yaml
@@ -1,0 +1,46 @@
+---
+- import_tasks: cleanup.yaml
+
+- import_tasks: generate_manifests.yaml
+
+- import_tasks: prometheus-operator.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: node-exporter.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: kube-state-metrics.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+# - import_tasks: prometheus-adapter.yaml
+
+- import_tasks: grafana.yaml
+  when:
+    - monitoring.grafana is defined
+    - monitoring.grafana.enabled is defined
+    - monitoring.grafana.enabled == true
+
+- import_tasks: prometheus.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: devops.yaml
+
+- import_tasks: etcd.yaml
+
+- import_tasks: prometheus-rules.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: alertmanager.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
+
+- import_tasks: notification-manager.yaml
+
+- import_tasks: monitoring-dashboard.yaml
+  when:
+    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"

--- a/roles/kubeedge/files/kubeedge/kubeedge/values.yaml
+++ b/roles/kubeedge/files/kubeedge/kubeedge/values.yaml
@@ -4,8 +4,8 @@
 appVersion: "0.1.0"
 
 cloudCore:
-  repository: "kubeedge/cloudcore"
-  tag: "v1.6.1"
+  repository: "kubespheredev/cloudcore"
+  tag: "v1.6.2"
   pullPolicy: "IfNotPresent"
   affinity:
     nodeAffinity:

--- a/roles/kubeedge/files/kubeedge/kubeedge/values.yaml
+++ b/roles/kubeedge/files/kubeedge/kubeedge/values.yaml
@@ -4,7 +4,7 @@
 appVersion: "0.1.0"
 
 cloudCore:
-  repository: "kubespheredev/cloudcore"
+  repository: "kubeedge/cloudcore"
   tag: "v1.6.2"
   pullPolicy: "IfNotPresent"
   affinity:

--- a/scripts/images-list.txt
+++ b/scripts/images-list.txt
@@ -131,7 +131,7 @@ kubesphere/openpitrix-jobs:v3.1.0
 ##weave-scope-images
 weaveworks/scope:1.13.0
 ##kubeedge-images
-kubeedge/cloudcore:v1.6.1
+kubespheredev/cloudcore:v1.6.2
 kubesphere/edge-watcher:v0.1.0
 kubesphere/kube-rbac-proxy:v0.5.0
 kubesphere/edge-watcher-agent:v0.1.0

--- a/scripts/images-list.txt
+++ b/scripts/images-list.txt
@@ -131,7 +131,7 @@ kubesphere/openpitrix-jobs:v3.1.0
 ##weave-scope-images
 weaveworks/scope:1.13.0
 ##kubeedge-images
-kubespheredev/cloudcore:v1.6.2
+kubeedge/cloudcore:v1.6.2
 kubesphere/edge-watcher:v0.1.0
 kubesphere/kube-rbac-proxy:v0.5.0
 kubesphere/edge-watcher-agent:v0.1.0


### PR DESCRIPTION
> cherry-pick-to-release-3.1

The pr description updates as following:
- commit 1 update kubespheredev image addr to support kubeedge v1.6.1, from #1527 at branch master, which have conflicts with current pr, have added a commit to fix conficts.
- commit 2 support external prometheus stack, fix #1503 , from #1528 at branch master.
- commit 3 update kubedge offical image addr to support kubeedge v1.6.2. from #1542 at branch master.

/cc @benjaminhuo @pixiake 