### PR TITLE
Update the default version to release-3.1

### DIFF
--- a/deploy/kubesphere-installer.yaml
+++ b/deploy/kubesphere-installer.yaml
@@ -264,7 +264,7 @@ spec:
       serviceAccountName: ks-installer
       containers:
       - name: installer
-        image: kubesphere/ks-installer:v3.1.0
+        image: kubespheredev/ks-installer:release-3.1
         imagePullPolicy: "Always"
         resources:
           limits:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -59,7 +59,7 @@ base_library_repo: >-
   {%- endif %}
 
 
-ks_image_tag: "{{ dev_tag | default('v3.1.0') }}"
+ks_image_tag: "{{ dev_tag | default('release-3.1') }}"
 
 # Containers
 # In some cases, we need a way to set --registry-mirror or --insecure-registry for docker,
@@ -71,9 +71,9 @@ ks_image_tag: "{{ dev_tag | default('v3.1.0') }}"
 # And use --insecure-registry options for docker
 
 #KubeSphere:
-ks_apiserver_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-apiserver"
+ks_apiserver_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/ks-apiserver"
 ks_apiserver_tag: "{{ ks_image_tag }}"
-ks_controller_manager_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-controller-manager"
+ks_controller_manager_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/ks-controller-manager"
 ks_controller_manager_tag: "{{ ks_image_tag }}"
 ks_update_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-upgrade"
 ks_update_tag: v3.0.0
@@ -81,7 +81,7 @@ ks_devops_migration_repo: "{{ base_repo }}{{ namespace_override | default('kubes
 ks_devops_migration_tag: "flyway-v3.0.0"
 ks_alerting_migration_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-alerting-migration"
 ks_alerting_migration_tag: "v3.1.0"
-ks_console_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-console"
+ks_console_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/ks-console"
 ks_console_tag: "{{ ks_image_tag }}"
 ks_kubectl_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/kubectl"
 ks_kubectl_tag: v1.0.0


### PR DESCRIPTION
The default tag is updated to release-3.1
The default namespace is updated to kubespheredev

default images:
kubespheredev/ks-apiserver:release-3.1
kubespheredev/ks-controller-manager:release-3.1
kubespheredev/ks-console:release-3.1
kubespheredev/ks-installer:release-3.1


Signed-off-by: pixiake <guofeng@yunify.com>