### PR TITLE
[release 3.1]cherry-pick #1533, fix kubeedge cloudcore component advertiseAddress configuration format error

### DIFF
--- a/roles/kubeedge/files/kubeedge/kubeedge/templates/configmap_kubeedge.yaml
+++ b/roles/kubeedge/files/kubeedge/kubeedge/templates/configmap_kubeedge.yaml
@@ -14,7 +14,10 @@ data:
       master: ""
     modules:
       cloudHub:
-        advertiseAddress: {{ .Values.cloudCore.cloudHub.advertiseAddress }}
+        advertiseAddress:
+        {{- range .Values.cloudCore.cloudHub.advertiseAddress }}
+        - {{  .  }}
+        {{- end}}
         nodeLimit: {{ .Values.cloudCore.cloudHub.nodeLimit }}
         tlsCAFile: /etc/kubeedge/ca/rootCA.crt
         tlsCertFile: /etc/kubeedge/certs/edge.crt


### PR DESCRIPTION
cherry-pick #1533, fix #1532, by @wenhuwang.
- fix kubeedge cloudcore component advertiseAddress configuration format error 

/cc @pixiake 
