### PR TITLE
[Manual cherrypick] delete old op job when update tag of image && update images tag of op-job

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -128,8 +128,8 @@ edge_watcher_agent_repo: "{{ base_repo }}{{ namespace_override | default('kubesp
 edge_watcher_agent_tag: "v0.1.0"
 
 #openpitrix:
-openpitrix_job_tag: "v3.1.0"
-openpitrix_job_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/openpitrix-jobs"
+openpitrix_job_tag: "v3.1.1-rc.1"
+openpitrix_job_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/openpitrix-jobs"
 
 minio_repo: "{{ base_repo }}{{ namespace_override | default('minio') }}/minio"
 minio_tag: RELEASE.2019-08-07T01-59-21Z

--- a/roles/openpitrix/tasks/main.yaml
+++ b/roles/openpitrix/tasks/main.yaml
@@ -17,8 +17,22 @@
     {{ bin_dir }}/kubectl get deploy openpitrix-hyperpitrix-deployment -n openpitrix-system 2>1 -oNAME | wc -l
   register: openpitrix_deploy_count
 
+- name: OpenPitrix | Check openpitrix jobs exists or not
+  shell: >
+    {{ bin_dir }}/kubectl get job openpitrix-import-job -n kubesphere-system 2>1 -oNAME | wc -l
+  register: openpitrix_job_count
+  when:
+    - openpitrix_deploy_count.stdout == "0"
+
+- name: OpenPitrix | Delete previous openpitrix jobs
+  shell: >
+    {{ bin_dir }}/kubectl delete job openpitrix-import-job -n kubesphere-system
+  when:
+    - openpitrix_job_count.stdout == "1"
+    - openpitrix_deploy_count.stdout == "0"
+
 - name: OpenPitrix | Import App
   shell: >
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/openpitrix/ks-openpitrix-import.yaml
   when:
-    - openpitrix_deploy_count.stdout=="0"
+    - openpitrix_deploy_count.stdout == "0"


### PR DESCRIPTION
When kubesphere/helm-charts is updated, the op job's image needs update too. So, ks-installer needs to delete the previous openpitrix-import job, beacause image of Job filed is immutable.

Fixes #1571 