### PR TITLE
Add dev_tag config in default cluster-configuration.yaml

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -12,6 +12,7 @@ spec:
   authentication:
     jwtSecret: ""           # Keep the jwtSecret consistent with the Host Cluster. Retrieve the jwtSecret by executing "kubectl -n kubesphere-system get cm kubesphere-config -o yaml | grep -v "apiVersion" | grep jwtSecret" on the Host Cluster.
   local_registry: ""        # Add your private registry address if it is needed.
+  dev_tag: ""               # Add your kubesphere image tag you want to install, by default it's same as ks-install release version.
   etcd:
     monitoring: false       # Enable or disable etcd monitoring dashboard installation. You have to create a Secret for etcd before you enable it.
     endpointIps: localhost  # etcd cluster EndpointIps. It can be a bunch of IPs here.

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -58,7 +58,12 @@ base_library_repo: >-
   {%- endif %}
 
 
-ks_version: "{{ dev_tag | default('v3.1.1-rc.1') }}"
+ks_version: >-
+  {%- if dev_tag is defined and dev_tag != "" -%}
+  "{{ dev_tag }}"
+  {%- else -%}
+  "v3.1.1-rc.1"
+  {%- endif %}
 
 # Containers
 # In some cases, we need a way to set --registry-mirror or --insecure-registry for docker,


### PR DESCRIPTION
During developing ks-installer,  it's userful to set dev_tag to stable kubesphere version to test ks-installer.
Add this config to cluster-configuration.yaml . Maybe someone else may need it.
