### PR TITLE
Cleanup left clusterRole and clusterRoleBindings in kubesphere-delete.sh

### DIFF
--- a/roles/common/tasks/init-namespaces.yaml
+++ b/roles/common/tasks/init-namespaces.yaml
@@ -65,20 +65,6 @@
   loop: "{{ ['default', 'kube-public', 'kube-system', systemNamespacesList] | flatten(1) }}"
 
 
-- name: KubeSphere | Creating ImagePullSecrets
-  shell: |
-    cat <<EOF | kubectl apply -f -
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: qingcloud
-        namespace: "{{ item }}"
-      data:
-        .dockerconfigjson: eyJhdXRocyI6eyJkb2NrZXJodWIucWluZ2Nsb3VkLmNvbSI6eyJhdXRoIjoiWjNWbGMzUTZaM1ZsYzNRPSJ9fX0=
-      type: kubernetes.io/dockerconfigjson
-    EOF
-  loop: "{{ ['default', 'kube-public', 'kube-system', systemNamespacesList] | flatten(1) }}"
-
 - name: KubeSphere | Labeling namespace for network policy
   shell: >
     for ns in `kubectl get ns -o jsonpath="{.items[*].metadata.name}"`; do kubectl label  ns $ns kubesphere.io/namespace=$ns --overwrite; done

--- a/scripts/kubesphere-delete.sh
+++ b/scripts/kubesphere-delete.sh
@@ -83,6 +83,34 @@ do
   delete_roles $ns
 done
 
+# delete clusterroles
+delete_cluster_roles() {
+  for role in `kubectl get clusterrole -l iam.kubesphere.io/role-template -o jsonpath="{.items[*].metadata.name}"`
+  do
+    kubectl delete clusterrole $role 2>/dev/null
+  done
+
+  for role in `kubectl get clusterroles | grep "kubesphere" | awk '{print $1}'| paste -sd " "`
+  do
+    kubectl delete clusterrole $role 2>/dev/null
+  done
+}
+delete_cluster_roles
+
+# delete clusterrolebindings
+delete_cluster_role_bindings() {
+  for rolebinding in `kubectl get clusterrolebindings -l iam.kubesphere.io/role-template -o jsonpath="{.items[*].metadata.name}"`
+  do
+    kubectl delete clusterrolebindings $rolebinding 2>/dev/null
+  done
+
+  for rolebinding in `kubectl get clusterrolebindings | grep "kubesphere" | awk '{print $1}'| paste -sd " "`
+  do
+    kubectl delete clusterrolebindings $rolebinding 2>/dev/null
+  done
+}
+delete_cluster_role_bindings
+
 # delete clusters
 for cluster in `kubectl get clusters -o jsonpath="{.items[*].metadata.name}"`
 do
@@ -132,7 +160,7 @@ kubectl delete devopsprojects --all 2>/dev/null
 
 
 # delete validatingwebhookconfigurations
-for webhook in ks-events-admission-validate users.iam.kubesphere.io network.kubesphere.io validating-webhook-configuration
+for webhook in ks-events-admission-validate users.iam.kubesphere.io network.kubesphere.io validating-webhook-configuration resourcesquotas.quota.kubesphere.io
 do
   kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io $webhook 2>/dev/null
 done


### PR DESCRIPTION
The script: kubesphere-delete.sh don't delete kubesphere related clusterRoles, clusterRoleBindings and secrets, which left some trash in k8s cluster and break the next installation of kubesphere.
