### PR TITLE
Support both v1beta1 and v1 snapshots 

### DIFF
--- a/roles/common/files/snapshot-controller/Chart.yaml
+++ b/roles/common/files/snapshot-controller/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 
-appVersion: 2.1.1
+appVersion: 4.0.0
 name: snapshot-controller
 description: A Helm chart for snapshot-controller
-version: 0.1.0
+version: 0.2.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-csi/external-snapshotter
 sources:
@@ -13,5 +13,5 @@ keywords:
   - controller
   - csi
 maintainers:
-  - name: Min Zhang
-    email: arminzhang@yunify.com
+  - name: Yang Zhou
+    email: yangzhou@yunify.com

--- a/roles/common/files/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshot_before119.yaml
+++ b/roles/common/files/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshot_before119.yaml
@@ -72,11 +72,6 @@ spec:
           name: Age
           type: date
       name: v1beta1
-      # This indicates the v1beta1 version of the custom resource is deprecated.
-      # API requests to this version receive a warning in the server response.
-      deprecated: true
-      # This overrides the default warning returned to clients making v1beta1 API requests.
-      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotClass is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotClass"
       schema:
         openAPIV3Schema:
           description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
@@ -305,11 +300,6 @@ spec:
           name: Age
           type: date
       name: v1beta1
-      # This indicates the v1beta1 version of the custom resource is deprecated.
-      # API requests to this version receive a warning in the server response.
-      deprecated: true
-      # This overrides the default warning returned to clients making v1beta1 API requests.
-      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotContent is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotContent"
       schema:
         openAPIV3Schema:
           description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
@@ -573,11 +563,6 @@ spec:
           name: Age
           type: date
       name: v1beta1
-      # This indicates the v1beta1 version of the custom resource is deprecated.
-      # API requests to this version receive a warning in the server response.
-      deprecated: true
-      # This overrides the default warning returned to clients making v1beta1 API requests.
-      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
       schema:
         openAPIV3Schema:
           description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.

--- a/roles/common/files/snapshot-controller/values.yaml
+++ b/roles/common/files/snapshot-controller/values.yaml
@@ -1,3 +1,3 @@
 repository: csiplugin/snapshot-controller
-tag: v2.0.1
+tag: v4.0.0
 pullPolicy: IfNotPresent

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -45,9 +45,13 @@
       with_items:
         - { name: custom-values-snapshot-controller, file: custom-values-snapshot-controller.yaml }
 
-    - name: KubeSphere | Removing old snapshot crd
+    - name: KubeSphere | Updating snapshot crd
       command: >
+        {% if kubernetes_version.stdout is version('v1.19.0', '>=') %}
         {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshot.yaml --force
+        {% else %}
+        {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshot_before119.yaml --force
+        {% endif %}
       failed_when: false
 
     - name: KubeSphere | Deploying snapshot controller

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -143,7 +143,7 @@ mc_tag: RELEASE.2019-08-07T23-14-43Z
 
 #ks-hostnic
 snapshot_controller_repo: "{{ base_repo }}{{ namespace_override | default('csiplugin') }}/snapshot-controller"
-snapshot_controller_tag: "v2.0.1"
+snapshot_controller_tag: "v4.0.0"
 
 #jenkins:
 jenkins_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-jenkins"


### PR DESCRIPTION
The snapshot-controller updated  to V4.0.0 to ensure support both v1beta1 and v1 snapshots .
Choose a suitable snapshot CRD according to the K8S version. 

/cc @pixiake @stoneshi-yunify  
/area storage
/kind feature