### PR TITLE
update common images' version

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -275,11 +275,11 @@ kiali_tag: v1.24
 
 #base:
 redis_repo: "{{ base_library_repo }}redis"
-redis_tag: 5.0.5-alpine
+redis_tag: 5.0.12-alpine
 haproxy_repo: "{{ base_library_repo }}haproxy"
-haproxy_tag: 2.0.4
+haproxy_tag: 2.0.22-alpine
 busybox_repo: "{{ base_library_repo }}alpine"
-busybox_tag: 3.10.4
+busybox_tag: 3.14
 etcd_image_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/etcd"
 etcd_image_tag: "{{ etcd_version }}{%- if image_arch != 'amd64' -%}-{{ image_arch }}{%- endif -%}"
 mysql_repo: "{{ base_library_repo }}mysql"


### PR DESCRIPTION
Update the following mirror version:

alpine:   
3.10.4 -> 3.14

redis:      
5.0.5-alpine -> 5.0.12-alpine

haproxy: 
2.0.4 -> 2.0.22-alpine

Signed-off-by: pixiake <guofeng@yunify.com>