### PR TITLE
Add kubectl v1.20.x supports and update kubectl 1.19.0 to 1.19.1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -91,7 +91,8 @@ ks_kubectl_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }
 ks_kubectl_tag: v1.0.0
 # kubectl versions
 ks_kubectl_versions:
-  v1.19.0: v1.19.0
+  v1.20.0: v1.20.0
+  v1.19.0: v1.19.1
   v1.18.0: v1.18.0
   v1.17.0: v1.17.0
   v1.16.0: v1.16.0


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>
Add kubectl v1.20.x supports and update kubectl 1.19.0 to 1.19.1