### PR TITLE
Change kiali auth strategy to token

### DIFF
--- a/roles/ks-istio/files/kiali/kiali-cr.yaml
+++ b/roles/ks-istio/files/kiali/kiali-cr.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   istio_namespace: istio-system
   auth:
-    strategy: "anonymous"
+    strategy: "token"
   deployment:
     accessible_namespaces: [ "**" ]
     image_name: "quay.io/kiali/kiali"


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

Change kiali auth strategy to the **token**, So that only authenticated users can access it.

ref kubesphere/kubesphere#4045

/hold