### PR TITLE
Fix regression issue failed to login due to forbidden error

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -101,7 +101,11 @@ metadata:
       package authz
       default allow = false
       allow = true {
-        allowedResources := ["users","clustermembers","workspacemembers","members"]
+        input.Resource == "users"
+        input.User.Name == input.Name
+      }
+      allow = true {
+        allowedResources := ["clustermembers","workspacemembers","members"]
         allowedResources[_] == input.Resource
         input.User.Name == input.Name
         allowedVerbs := ["get","list","watch"]


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

fix: https://github.com/kubesphere/kubesphere/issues/4061

User change password after the first-time login will encounter the following problem:

> Login failed due to forbidden error: user.iam.kubesphere.io \"\" is forbidden: User \"\" cannot patch resource \"users\" in API group  \"iam.kubesphere.io\" at the cluster scope.