### PR TITLE
Fix: add missing  monitoring-dashboard CRD files while specifying an existing Prometheus stack during installation

### DIFF
--- a/roles/ks-monitor/tasks/generate_manifests.yaml
+++ b/roles/ks-monitor/tasks/generate_manifests.yaml
@@ -5,7 +5,6 @@
     dest: "{{ kubesphere_dir }}/"
   loop:
     - "prometheus"
-    - "monitoring-dashboard"
 
 - import_tasks: get_old_config.yaml
 

--- a/roles/ks-monitor/tasks/monitoring-dashboard.yaml
+++ b/roles/ks-monitor/tasks/monitoring-dashboard.yaml
@@ -1,4 +1,12 @@
 ---
+
+- name: Monitoring | Getting monitoring-dashboard installation files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ kubesphere_dir }}/"
+  loop:
+    - "monitoring-dashboard"
+
 - name: Monitoring | Installing monitoring-dashboard
   shell: >
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/monitoring-dashboard

--- a/roles/ks-monitor/tasks/prometheus-stack.yaml
+++ b/roles/ks-monitor/tasks/prometheus-stack.yaml
@@ -42,7 +42,3 @@
 - import_tasks: notification-manager.yaml
   when:
     - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"
-
-- import_tasks: monitoring-dashboard.yaml
-  when:
-    - "status.monitoring is not defined or status.monitoring.status is not defined or status.monitoring.status != 'enabled'"


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

Add missing CRD files while specifying an existing Prometheus stack during installation:
- pick out monitoring-dashboard in loop items at modify roles/ks-monitor/tasks/generate_manifests.yaml
- add logic to copy monitoring-dashboard files at roles/ks-monitor/tasks/monitoring-dashboard.yaml
- remove repetitive logic at roles/ks-monitor/tasks/prometheus-stack.yaml