### PR TITLE
add host local time to kube-state-metrics

### DIFF
--- a/roles/ks-monitor/templates/kube-state-metrics-deployment.yaml.j2
+++ b/roles/ks-monitor/templates/kube-state-metrics-deployment.yaml.j2
@@ -17,6 +17,11 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/version: 1.9.7
     spec:
+      volumes:
+      - name: host-time
+        hostPath:
+          path: /etc/localtime
+          type: ""
       containers:
       - args:
         - --host=127.0.0.1
@@ -35,6 +40,10 @@ spec:
             memory: {{ monitoring.kube_state_metrics.requests.memory | default("150Mi") }}
         securityContext:
           runAsUser: 65534
+        volumeMounts:
+        - name: host-time
+          mountPath: /etc/localtime
+          readOnly: true
       - args:
         - --logtostderr
         - --secure-listen-address=:8443


### PR DESCRIPTION
This pull request binds the time zone of the kube-state-metrics component to the host time zone to be consistent with the kube-controller-manager, which does this binding by default.

It fixes https://github.com/kubesphere/kubesphere/issues/4099 : `KubeCronJobRunning` alerts are related to the `kube_cronjob_next_schedule_time` metric, which is calculated by the kube-state-metrics component based on the cronJob instance's last schedule time and cron expression, so when no time zone is specified in a cron expression, the local’s is used.

/assign @benjaminhuo @pixiake 