### PR TITLE
update ansible and helm

### DIFF
--- a/Dockerfile.shelloperator
+++ b/Dockerfile.shelloperator
@@ -38,18 +38,7 @@ RUN chown -R kubesphere:kubesphere /shell-operator && \
 ADD controller/* /hooks/kubesphere/
 RUN chmod +x -R /hooks/kubesphere
 
-USER kubesphere
-
 ENV SHELL_OPERATOR_WORKING_DIR /hooks
-ENV ANSIBLE_ROLES_PATH /kubesphere/installer/roles
-
-WORKDIR /kubesphere
-
-ADD roles /kubesphere/installer/roles
-
-ADD env /kubesphere/results/env
-
-ADD playbooks /kubesphere/playbooks
 
 ENTRYPOINT ["/shell-operator"]
 

--- a/roles/check-result/tasks/main.yaml
+++ b/roles/check-result/tasks/main.yaml
@@ -29,9 +29,9 @@
     --type merge
     -p '{"status": {"core": {"version": "{{ ks_version }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3
 

--- a/roles/common/files/minio-ha/templates/deployment.yaml
+++ b/roles/common/files/minio-ha/templates/deployment.yaml
@@ -180,7 +180,7 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       volumes:
-        {{- if and ((not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled)) }}
+        {{- if and (not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) }}
         - name: export
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/roles/common/files/openldap-ha/templates/statefulset.yaml
+++ b/roles/common/files/openldap-ha/templates/statefulset.yaml
@@ -22,7 +22,7 @@ metadata:
 {{ include "openldap-ha.labels" . | indent 4 }}
 spec:
   serviceName: {{ include "openldap-ha.fullname" . }}
-  {{- if (.Values.ldap.replication) and eq .Values.ldap.replication "true" }}
+  {{- if .Values.ldap.replication }}
   replicas: 2
   {{- else }}
   replicas: 1
@@ -69,7 +69,7 @@ spec:
                 fieldPath: metadata.name
           - name: HOSTNAME
             value: "$(MY_POD_NAME).{{ include "openldap-ha.fullname" . }}"
-          {{- if (.Values.ldap.replication) and eq .Values.ldap.replication true }}
+          {{- if .Values.ldap.replication }}
           - name: LDAP_REPLICATION_CONFIG_SYNCPROV
             value: "binddn=\"cn=admin,cn=config\" bindmethod=simple credentials=$LDAP_CONFIG_PASSWORD searchbase=\"cn=config\" type=refreshAndPersist retry=\"60 +\" timeout=1"
           - name: LDAP_REPLICATION_DB_SYNCPROV

--- a/roles/common/tasks/es-install.yaml
+++ b/roles/common/tasks/es-install.yaml
@@ -107,9 +107,9 @@
       --type merge
       -p '{"status": {"es": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
       -n kubesphere-system
-    register: import
-    failed_when: "import.stderr and 'Warning' not in import.stderr"
-    until: import is succeeded
+    register: cc_result
+    failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+    until: cc_result is succeeded
     retries: 5
     delay: 3
 

--- a/roles/common/tasks/fluentbit-install.yaml
+++ b/roles/common/tasks/fluentbit-install.yaml
@@ -61,8 +61,8 @@
 - name: KubeSphere | Deploying new fluentbit operator
   shell: >
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/fluentbit-operator/fluentbit
-  register: import
-  until: import is succeeded
+  register: fluentbit_result
+  until: fluentbit_result is succeeded
   retries: 5
   delay: 3
 
@@ -74,8 +74,8 @@
     --type merge
     -p '{"status": {"fluentbit": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -151,10 +151,10 @@
       loop:
         - "etcd.yaml"
         - "mysql.yaml"
-      register: import
+      register: common_result
       failed_when:
-        - "import.stderr and 'is immutable after creation except resources.requests for bound claims' not in import.stderr"
-        - "import.stderr and 'is forbidden' not in import.stderr"
+        - "common_result.stderr and 'is immutable after creation except resources.requests for bound claims' not in common_result.stderr"
+        - "common_result.stderr and 'is forbidden' not in common_result.stderr"
 
 
     - import_tasks: minio-install.yaml

--- a/roles/common/tasks/minio-install.yaml
+++ b/roles/common/tasks/minio-install.yaml
@@ -57,8 +57,8 @@
     --type merge
     -p '{"status": {"minio": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/common/tasks/minio-migration.yaml
+++ b/roles/common/tasks/minio-migration.yaml
@@ -17,8 +17,8 @@
 - name: KubeSphere | Checking minio status
   shell: >
     {{ bin_dir }}/kubectl get pod -n kubesphere-system | grep 'minio' | grep -v 'Running' | wc -l
-  register: import
-  until: import.stdout == "0"
+  register: minio_result
+  until: minio_result.stdout == "0"
   retries: 30
   delay: 30
 

--- a/roles/common/tasks/mysql-install.yaml
+++ b/roles/common/tasks/mysql-install.yaml
@@ -4,10 +4,10 @@
     {{ bin_dir }}/kubectl -n kubesphere-system apply -f {{ kubesphere_dir }}/common/{{ item }}
   loop:
     - "mysql.yaml"
-  register: import
+  register: mysql_result
   failed_when:
-    - "import.stderr and 'is immutable after creation except resources.requests for bound claims' not in import.stderr"
-    - "import.stderr and 'is forbidden' not in import.stderr"
+    - "mysql_result.stderr and 'is immutable after creation except resources.requests for bound claims' not in mysql_result.stderr"
+    - "mysql_result.stderr and 'is forbidden' not in mysql_result.stderr"
 #  when: devops.enabled or openpitrix.enabled or notification.enabled or alerting.enabled
 
 - name: KubeSphere | Importing mysql status
@@ -16,8 +16,8 @@
     --type merge
     -p '{"status": {"mysql": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/common/tasks/openldap-install.yaml
+++ b/roles/common/tasks/openldap-install.yaml
@@ -71,8 +71,8 @@
     --type merge
     -p '{"status": {"openldap": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/common/tasks/openldap-migration.yaml
+++ b/roles/common/tasks/openldap-migration.yaml
@@ -11,8 +11,8 @@
   shell: >
     {{ bin_dir }}/kubectl get pod -n kubesphere-system
     -l app.kubernetes.io/name=openldap-ha | awk '{if(NR>1){print}}' | grep -v '1/1' | wc -l
-  register: import
-  until: import.stdout == "0"
+  register: openldap_result
+  until: openldap_result.stdout == "0"
   retries: 30
   delay: 30
 

--- a/roles/common/tasks/redis-install.yaml
+++ b/roles/common/tasks/redis-install.yaml
@@ -48,20 +48,20 @@
         --namespace kubesphere-system
 
 
-    - name: KubeSphere | Getting redis PodIp
-      shell: >
-        {{ bin_dir }}/kubectl get pod
-        -n kubesphere-system
-        -l  app=redis,tier=database,version=redis-4.0
-        -ojsonpath='{.items[0].status.podIP}'
-      register: redis_podIp
-      when:
-        - old_redis_exist.stdout != "0"
-
-
-    - import_tasks: redis-migration.yaml
-      when:
-        - old_redis_exist.stdout != "0"
+#    - name: KubeSphere | Getting redis PodIp
+#      shell: >
+#        {{ bin_dir }}/kubectl get pod
+#        -n kubesphere-system
+#        -l  app=redis,tier=database,version=redis-4.0
+#        -ojsonpath='{.items[0].status.podIP}'
+#      register: redis_podIp
+#      when:
+#        - old_redis_exist.stdout != "0"
+#
+#
+#    - import_tasks: redis-migration.yaml
+#      when:
+#        - old_redis_exist.stdout != "0"
 
   when:
     - enableHA is defined and enableHA
@@ -73,10 +73,10 @@
     {{ bin_dir }}/kubectl -n kubesphere-system apply -f {{ kubesphere_dir }}/common/{{ item }}
   loop:
     - "redis.yaml"
-  register: import
+  register: redis_result
   failed_when:
-    - "import.stderr and 'bound claims' not in import.stderr"
-    - "import.stderr and 'is forbidden' not in import.stderr"
+    - "redis_result.stderr and 'bound claims' not in redis_result.stderr"
+    - "redis_result.stderr and 'is forbidden' not in redis_result.stderr"
   when:
     - (enableHA is defined and not enableHA) or (enableHA is not defined)
 
@@ -87,8 +87,8 @@
     --type merge
     -p '{"status": {"redis": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/common/tasks/redis-migration.yaml
+++ b/roles/common/tasks/redis-migration.yaml
@@ -10,8 +10,8 @@
 - name: KubeSphere | Checking redis-ha status
   shell: >
     {{ bin_dir }}/kubectl get pod -n kubesphere-system | grep 'redis-ha' | grep -v 'Running' | wc -l
-  register: import
-  until: import.stdout == "0"
+  register: redis_result
+  until: redis_result.stdout == "0"
   retries: 30
   delay: 30
 

--- a/roles/ks-alerting/tasks/main.yaml
+++ b/roles/ks-alerting/tasks/main.yaml
@@ -87,9 +87,9 @@
     --type merge
     -p '{"status": {"alerting": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3
 

--- a/roles/ks-auditing/tasks/main.yaml
+++ b/roles/ks-auditing/tasks/main.yaml
@@ -44,8 +44,8 @@
     --type merge
     -p '{"status": {"auditing": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/ks-core/config/tasks/main.yaml
+++ b/roles/ks-core/config/tasks/main.yaml
@@ -111,7 +111,7 @@
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/{{ item }}"
   loop:
     - "kubesphere-config.yaml"
-  register: import
-  failed_when: "import.stderr and 'AlreadyExists' not in import.stderr"
+  register: init_result
+  failed_when: "init_result.stderr and 'AlreadyExists' not in init_result.stderr"
 
 - import_tasks: ks-restart.yaml

--- a/roles/ks-core/ks-core/tasks/main.yaml
+++ b/roles/ks-core/ks-core/tasks/main.yaml
@@ -109,8 +109,8 @@
     --type merge
     -p '{"status": {"core": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/ks-core/prepare/tasks/main.yaml
+++ b/roles/ks-core/prepare/tasks/main.yaml
@@ -34,9 +34,9 @@
       --type merge
       -p '{"status": {"core": {"migration": true}}}'
       -n kubesphere-system
-    register: import
-    failed_when: "import.stderr and 'Warning' not in import.stderr"
-    until: import is succeeded
+    register: cc_result
+    failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+    until: cc_result is succeeded
     retries: 5
     delay: 3
   - set_fact:
@@ -75,8 +75,8 @@
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/ks-init/{{ item }}"
   loop:
     - "role-templates.yaml"
-  register: import
-  failed_when: "import.stderr and 'AlreadyExists' not in import.stderr and 'Warning' not in import.stderr"
+  register: init_ks_result
+  failed_when: "init_ks_result.stderr and 'AlreadyExists' not in init_ks_result.stderr and 'Warning' not in init_ks_result.stderr"
 
 
 - name: KubeSphere | Generating kubeconfig-admin
@@ -87,6 +87,6 @@
 
 - name: KubeSphere | Creating Storage ProvisionerCapability
   shell: "{{ bin_dir }}/kubectl apply -R -f {{ kubesphere_dir }}/provisonercapability"
-  register: import
-  failed_when: "import.stderr and 'Warning: kubectl apply' not in import.stderr"
+  register: storage_pc_result
+  failed_when: "storage_pc_result.stderr and 'Warning: kubectl apply' not in storage_pc_result.stderr"
 

--- a/roles/ks-devops/jenkins/tasks/main.yaml
+++ b/roles/ks-devops/jenkins/tasks/main.yaml
@@ -96,8 +96,8 @@
     --type merge
     -p '{"status": {"devops": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/ks-devops/s2i/tasks/main.yaml
+++ b/roles/ks-devops/s2i/tasks/main.yaml
@@ -32,8 +32,8 @@
     - binary.yaml
     - tomcat.yaml
     - s2ioperator.yaml
-  register: import
-  until: import is succeeded
+  register: s2i_result
+  until: s2i_result is succeeded
   retries: 3
   delay: 3
   failed_when: false

--- a/roles/ks-events/tasks/main.yaml
+++ b/roles/ks-events/tasks/main.yaml
@@ -32,7 +32,6 @@
     {{ kubesphere_dir }}/ks-events/kube-events
     -f {{ kubesphere_dir }}/ks-events/custom-values-events.yaml
     -n kubesphere-logging-system
-    --force
   register: deploy_result
   until: deploy_result is succeeded
   retries: 3
@@ -50,9 +49,9 @@
     --type merge
     -p '{"status": {"events": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3
 
@@ -63,9 +62,9 @@
     --type merge
     -p '{"status": {"events": {"ruler": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3
   when:

--- a/roles/ks-istio/tasks/jaeger-install.yaml
+++ b/roles/ks-istio/tasks/jaeger-install.yaml
@@ -21,8 +21,8 @@
 
 - name: servicemesh | Deploying jaeger-secret
   shell: "{{ bin_dir }}/kubectl create secret generic jaeger-secret --from-literal=ES_PASSWORD={{ common.es.basicAuth.password }} --from-literal=ES_USERNAME={{ common.es.basicAuth.username }} --namespace istio-system"
-  register: import
-  until: import is succeeded
+  register: jaeger_result
+  until: jaeger_result is succeeded
   retries: 5
   delay: 10
   when:
@@ -33,8 +33,8 @@
 
 - name: servicemesh | Deploying jaeger-cr
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/servicemesh/jaeger/jaeger-cr.yaml --namespace istio-system"
-  register: import
-  until: import is succeeded
+  register: jaeger_cr_result
+  until: jaeger_cr_result is succeeded
   retries: 5
   delay: 10
   when:

--- a/roles/ks-istio/tasks/kiali-install.yaml
+++ b/roles/ks-istio/tasks/kiali-install.yaml
@@ -21,8 +21,8 @@
 
 - name: servicemesh | Deploying kiali-cr
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/servicemesh/kiali/kiali-cr.yaml --namespace istio-system"
-  register: import
-  until: import is succeeded
+  register: kiali_cr_result
+  until: kiali_cr_result is succeeded
   retries: 5
   delay: 10
   when:

--- a/roles/ks-istio/tasks/main.yaml
+++ b/roles/ks-istio/tasks/main.yaml
@@ -104,9 +104,9 @@
   shell: >
     {{ bin_dir }}/kubectl -n istio-system patch hpa istiod-1-6-10
     --type merge -p '{"spec":{"scaleTargetRef":{"name":"istiod-1-6-10"}}}'
-  register: import
-  failed_when: "import.stderr"
-  until: import is succeeded
+  register: patch_result
+  failed_when: "patch_result.stderr"
+  until: patch_result is succeeded
   retries: 5
   delay: 3
 
@@ -121,9 +121,9 @@
     --type merge
     -p '{"status": {"servicemesh": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3
   when:
@@ -135,9 +135,9 @@
     --type merge
     -p '{"status": {"servicemesh": {"status": "failed", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3
   when:

--- a/roles/ks-logging/tasks/main.yaml
+++ b/roles/ks-logging/tasks/main.yaml
@@ -36,8 +36,8 @@
     --type merge
     -p '{"status": {"logging": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/ks-migration/tasks/main.yaml
+++ b/roles/ks-migration/tasks/main.yaml
@@ -83,9 +83,9 @@
       --type merge
       -p '{"status": {"core": {"migration": null}}}'
       -n kubesphere-system
-    register: import
-    failed_when: "import.stderr and 'Warning' not in import.stderr"
-    until: import is succeeded
+    register: cc_result
+    failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+    until: cc_result is succeeded
     retries: 5
     delay: 3
   when:

--- a/roles/ks-monitor/tasks/cleanup.yaml
+++ b/roles/ks-monitor/tasks/cleanup.yaml
@@ -14,8 +14,8 @@
 
 - name: Monitoring | Deleting old prometheus-operator
   shell: "{{ bin_dir }}/kubectl delete -f {{ kubesphere_dir }}/prometheus/"
-  register: import
-  failed_when: "import.stderr and 'NotFound' not in import.stderr"
+  register: delete_result
+  failed_when: "delete_result.stderr and 'NotFound' not in delete_result.stderr"
   when: prometheus_old_check.stat.exists
 
 - name: Monitoring | Deleting old prometheus-operator files

--- a/roles/ks-monitor/tasks/devops.yaml
+++ b/roles/ks-monitor/tasks/devops.yaml
@@ -3,9 +3,9 @@
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/prometheus/{{ item }}"
   loop:
     - "devops"
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr and 'spec.clusterIP' not in import.stderr"
-  until: import is succeeded
+  register: devops_result
+  failed_when: "devops_result.stderr and 'Warning' not in devops_result.stderr and 'spec.clusterIP' not in devops_result.stderr"
+  until: devops_result is succeeded
   retries: 5
   delay: 3
   when:

--- a/roles/ks-monitor/tasks/etcd.yaml
+++ b/roles/ks-monitor/tasks/etcd.yaml
@@ -3,9 +3,9 @@
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/prometheus/{{ item }}"
   loop:
     - "etcd"
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr and 'spec.clusterIP' not in import.stderr"
-  until: import is succeeded
+  register: etcd_result
+  failed_when: "etcd_result.stderr and 'Warning' not in etcd_result.stderr and 'spec.clusterIP' not in etcd_result.stderr"
+  until: etcd_result is succeeded
   retries: 5
   delay: 3
   when:

--- a/roles/ks-monitor/tasks/main.yaml
+++ b/roles/ks-monitor/tasks/main.yaml
@@ -12,9 +12,9 @@
     --type merge
     -p '{"status": {"monitoring": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3
 

--- a/roles/ks-monitor/tasks/notification-manager.yaml
+++ b/roles/ks-monitor/tasks/notification-manager.yaml
@@ -99,9 +99,9 @@
 
 - name: notification-manager | Deploying federatednamespace crd
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/federated/federatednamespaces.yaml"
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr and 'spec.clusterIP' not in import.stderr"
-  until: import is succeeded
+  register: fed_result
+  failed_when: "fed_result.stderr and 'Warning' not in fed_result.stderr and 'spec.clusterIP' not in fed_result.stderr"
+  until: fed_result is succeeded
   retries: 5
   delay: 3
   when:
@@ -116,9 +116,9 @@
 
 - name: notification-manager | Deploying federated namespace
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/federated/kubesphere-monitoring-federated.yaml"
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr and 'spec.clusterIP' not in import.stderr"
-  until: import is succeeded
+  register: fed_result
+  failed_when: "fed_result.stderr and 'Warning' not in fed_result.stderr and 'spec.clusterIP' not in fed_result.stderr"
+  until: fed_result is succeeded
   retries: 5
   delay: 3
   when:

--- a/roles/ks-monitor/tasks/prometheus-operator.yaml
+++ b/roles/ks-monitor/tasks/prometheus-operator.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Monitoring | Initing prometheus-operator
   shell: "{{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/prometheus/init --force"
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr and 'spec.clusterIP' not in import.stderr"
-  until: import is succeeded
+  register: prom_result
+  failed_when: "prom_result.stderr and 'Warning' not in prom_result.stderr and 'spec.clusterIP' not in prom_result.stderr"
+  until: prom_result is succeeded
   retries: 5
   delay: 3

--- a/roles/ks-monitor/tasks/prometheus.yaml
+++ b/roles/ks-monitor/tasks/prometheus.yaml
@@ -4,8 +4,8 @@
   loop:
     - "prometheus"
     - "prometheus"
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr and 'spec.clusterIP' not in import.stderr"
-  until: import is succeeded
+  register: prom_result
+  failed_when: "prom_result.stderr and 'Warning' not in prom_result.stderr and 'spec.clusterIP' not in prom_result.stderr"
+  until: prom_result is succeeded
   retries: 5
   delay: 3

--- a/roles/ks-monitor/tasks/thanosruler.yaml
+++ b/roles/ks-monitor/tasks/thanosruler.yaml
@@ -9,8 +9,8 @@
     --type merge
     -p '{"status": {"alerting": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/ks-multicluster/tasks/main.yml
+++ b/roles/ks-multicluster/tasks/main.yml
@@ -68,8 +68,8 @@
     --type merge
     -p '{"status": {"multicluster": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/ks-network/topology/weave-scope/tasks/main.yaml
+++ b/roles/ks-network/topology/weave-scope/tasks/main.yaml
@@ -19,9 +19,9 @@
 - name: weave-scope | Deploying weave-scope
   shell: >
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/weave-scope/weave-scope.yaml
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr and 'spec.clusterIP' not in import.stderr"
-  until: import is succeeded
+  register: weave_result
+  failed_when: "weave_result.stderr and 'Warning' not in weave_result.stderr and 'spec.clusterIP' not in weave_result.stderr"
+  until: weave_result is succeeded
   retries: 5
   delay: 3
 
@@ -31,9 +31,9 @@
     --type merge
     -p '{"status": {"network": {"topology": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3
 

--- a/roles/ks-notification/tasks/main.yaml
+++ b/roles/ks-notification/tasks/main.yaml
@@ -76,8 +76,8 @@
     --type merge
     -p '{"status": {"notification": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/kubeedge/tasks/main.yaml
+++ b/roles/kubeedge/tasks/main.yaml
@@ -37,8 +37,8 @@
     --type merge
     -p '{"status": {"kubeedge": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3

--- a/roles/metrics-server/tasks/main.yml
+++ b/roles/metrics-server/tasks/main.yml
@@ -51,8 +51,8 @@
     --type merge
     -p '{"status": {"metricsServer": {"status": "enabled", "enabledTime": "{{ lookup('pipe','date  +%Y-%m-%dT%H:%M:%S%Z') }}"}}}'
     -n kubesphere-system
-  register: import
-  failed_when: "import.stderr and 'Warning' not in import.stderr"
-  until: import is succeeded
+  register: cc_result
+  failed_when: "cc_result.stderr and 'Warning' not in cc_result.stderr"
+  until: cc_result is succeeded
   retries: 5
   delay: 3


### PR DESCRIPTION
ansible to 2.9.23
helm to v3.6.3

`import` is the key word in Ansible, The new version of the Ansible does not allow keywords as variable names.

Signed-off-by: pixiake <guofeng@yunify.com>