### PR TITLE
Secure Redis connection between ks-apiserver

### DIFF
--- a/roles/common/files/redis-ha/templates/_configs.tpl
+++ b/roles/common/files/redis-ha/templates/_configs.tpl
@@ -157,8 +157,8 @@
       mode tcp
       option tcp-check
       tcp-check connect
-      {{- if $root.auth }}
-      tcp-check send AUTH\ {{ $root.redisPassword }}\r\n
+      {{- if $root.Values.auth }}
+      tcp-check send AUTH\ REPLACE_AUTH_SECRET\r\n
       tcp-check expect string +OK
       {{- end }}
       tcp-check send PING\r\n
@@ -189,7 +189,7 @@
       option tcp-check
       tcp-check connect
       {{- if .Values.auth }}
-      tcp-check send AUTH\ {{ .Values.redisPassword }}\r\n
+      tcp-check send AUTH\ REPLACE_AUTH_SECRET\r\n
       tcp-check expect string +OK
       {{- end }}
       tcp-check send PING\r\n
@@ -208,7 +208,7 @@
       option tcp-check
       tcp-check connect
       {{- if .Values.auth }}
-      tcp-check send AUTH\ {{ .Values.redisPassword }}\r\n
+      tcp-check send AUTH\ REPLACE_AUTH_SECRET\r\n
       tcp-check expect string +OK
       {{- end }}
       tcp-check send PING\r\n
@@ -241,5 +241,10 @@
       exit 1
     fi
     sed -i "s/REPLACE_ANNOUNCE{{ $i }}/$ANNOUNCE_IP{{ $i }}/" "$HAPROXY_CONF"
+    if [ "${AUTH:-}" ]; then
+        echo "Setting auth values"
+        ESCAPED_AUTH=$(echo "$AUTH" | sed -e 's/[\/&]/\\&/g');
+        sed -i "s/REPLACE_AUTH_SECRET/${ESCAPED_AUTH}/" "$HAPROXY_CONF"
+    fi
     {{- end }}
 {{- end }}

--- a/roles/common/files/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/roles/common/files/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -58,6 +58,18 @@ spec:
         - sh
         args:
         - /readonly/haproxy_init.sh
+{{- if .Values.auth }}
+        env:
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.existingSecret }}
+              name: {{ .Values.existingSecret }}
+            {{- else }}
+              name: {{ template "redis-ha.fullname" . }}
+            {{- end }}
+              key: {{ .Values.authKey }}
+{{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /readonly

--- a/roles/common/tasks/redis-install.yaml
+++ b/roles/common/tasks/redis-install.yaml
@@ -1,9 +1,3 @@
-- name: KubeSphere | Checking ha-redis
-  shell: >
-    {{ bin_dir }}/helm list -n kubesphere-system | grep "ks-redis"
-  register: redis_check
-  failed_when: false
-
 - name: KubeSphere | Init Redis password
   block:
     - name: KubeSphere | Generet Random password
@@ -75,7 +69,6 @@
 
   when:
     - enableHA is defined and enableHA
-    - (redis_check.stdout.find("deployed") == -1) or (redis_check.stdout.find("5.0.5") == -1)
 
 
 - name: KubeSphere | Deploying redis

--- a/roles/common/tasks/redis-install.yaml
+++ b/roles/common/tasks/redis-install.yaml
@@ -4,6 +4,16 @@
   register: redis_check
   failed_when: false
 
+- name: KubeSphere | Init Redis password
+  block:
+    - name: KubeSphere | Generet Random password
+      set_fact:
+        redis_password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
+    - name: KubeSphere | Creating Redis Password Secret
+      shell: >
+        {{ bin_dir }}/kubectl -n kubesphere-system create secret generic redis-secret --from-literal=auth={{redis_password}}
+      register: secret
+      failed_when: "secret.stderr and 'AlreadyExists' not in secret.stderr"
 
 - name: KubeSphere | Deploying ha redis
   block:

--- a/roles/common/templates/custom-values-redis.yaml.j2
+++ b/roles/common/templates/custom-values-redis.yaml.j2
@@ -217,11 +217,12 @@ podDisruptionBudget: {}
   # minAvailable: 1
 
 ## Configures redis with AUTH (requirepass & masterauth conf params)
-auth: false
+auth: true
 # redisPassword:
 
 ## Use existing secret containing key `authKey` (ignores redisPassword)
-# existingSecret:
+existingSecret: redis-secret
+  
 
 ## Defines the key holding the redis password in existing secret.
 authKey: auth

--- a/roles/common/templates/redis.yaml.j2
+++ b/roles/common/templates/redis.yaml.j2
@@ -38,10 +38,28 @@ spec:
         tier: database
         version: redis-4.0
     spec:
+      initContainers:
+      - name: init
+        image: {{ redis_repo }}:{{ redis_tag }}
+        command: ['sh', '-c', 'cat /tmp/redis/redis.conf | sed "s/REDIS_PASSWORD/$KUBESPHERE_REDIS_PASSWORD/" > /data/redis.conf']
+        volumeMounts:
+        - mountPath: /data
+          name: redis-pvc
+          subPath: redis-data
+        - name: redis-config
+          mountPath: "/tmp/redis"
+          readOnly: true
+        env:
+        - name: KUBESPHERE_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: redis-secret
+              key: auth
       containers:
       - image: {{ redis_repo }}:{{ redis_tag }}
         imagePullPolicy: IfNotPresent
         name: redis
+        args: ["/data/redis.conf"]
         volumeMounts:
         - mountPath: /data
           name: redis-pvc
@@ -60,6 +78,9 @@ spec:
       - name: redis-pvc
         persistentVolumeClaim:
           claimName: redis-pvc
+      - name: redis-config
+        configMap:
+          name: redis-configmap
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
@@ -76,6 +97,20 @@ spec:
                 values:
                 - "" 
 
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-configmap
+  labels:
+    app: redis
+    tier: database
+    version: redis-4.0
+data:
+  redis.conf: |
+    requirepass REDIS_PASSWORD
+    masterauth REDIS_PASSWORD
 
 ---
 

--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -30,7 +30,7 @@ data:
     redis:
       host: redis.kubesphere-system.svc
       port: 6379
-      password: {{ common.redisPasswd | default('""') }}
+      password: KUBESPHERE_REDIS_PASSWORD
       db: 0
 {% endif %}
 

--- a/roles/ks-core/ks-core/templates/custom-values-ks-core.yaml.j2
+++ b/roles/ks-core/ks-core/templates/custom-values-ks-core.yaml.j2
@@ -47,3 +47,11 @@ controllerManagerResources:
   requests:
     cpu: {{ common.controllerManager.resources.requests.cpu | default('30m') }}
     memory: {{ common.controllerManager.resources.requests.memory | default('50Mi') }}
+{% if (common.redis is defined and common.redis.enabled is defined and common.redis.enabled) or enableHA %}
+env:
+- name: KUBESPHERE_REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: redis-secret
+      key: auth
+{% endif %}

--- a/roles/ks-core/ks-core/templates/custom-values-ks-core.yaml.j2
+++ b/roles/ks-core/ks-core/templates/custom-values-ks-core.yaml.j2
@@ -47,7 +47,7 @@ controllerManagerResources:
   requests:
     cpu: {{ common.controllerManager.resources.requests.cpu | default('30m') }}
     memory: {{ common.controllerManager.resources.requests.memory | default('50Mi') }}
-{% if (common.redis is defined and common.redis.enabled is defined and common.redis.enabled) or enableHA %}
+{% if (common.redis is defined and common.redis.enabled is defined and common.redis.enabled) or (enableHA is defined and enableHA) %}
 env:
 - name: KUBESPHERE_REDIS_PASSWORD
   valueFrom:


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
This PR enables Redis authentication by default.  Ks-apiserver will use secure connections.

Redis' password will be generated randomly and saved into` redis-secret both ks-apiserver and Redis will mount it into environment variables.

There's a health check issue that was fixed in the redis-ha helm chart when authentication was enabled.

### Which issue(s) this PR fixes:
Fixes # kubesphere/kubesphere#4045

