### PR TITLE
Set read-only permissions for hostpath volume

### DIFF
--- a/deploy/kubesphere-installer.yaml
+++ b/deploy/kubesphere-installer.yaml
@@ -282,6 +282,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
       volumes:
       - hostPath:
           path: /etc/localtime

--- a/roles/ks-auditing/files/kube-auditing/templates/operator.yaml
+++ b/roles/ks-auditing/files/kube-auditing/templates/operator.yaml
@@ -41,6 +41,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/localtime
               name: host-time
+              readOnly: true
       volumes:
         - hostPath:
             path: /etc/localtime

--- a/roles/ks-core/ks-core/files/ks-core/templates/ks-apiserver.yml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/ks-apiserver.yml
@@ -43,12 +43,14 @@ spec:
         volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-sock
+          readOnly: true
         - mountPath: /etc/kubesphere/ingress-controller
           name: ks-router-config
         - mountPath: /etc/kubesphere/
           name: kubesphere-config
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
         env:
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}

--- a/roles/ks-core/ks-core/files/ks-core/templates/ks-console.yml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/ks-console.yml
@@ -36,6 +36,7 @@ spec:
           name: sample-bookinfo
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
         livenessProbe:
           tcpSocket:
             port: 8000

--- a/roles/ks-core/ks-core/files/ks-core/templates/ks-controller-manager.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/ks-controller-manager.yaml
@@ -52,6 +52,7 @@ spec:
           name: webhook-secret
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
         env:
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}

--- a/roles/ks-events/files/kube-events/templates/operator/deploy.yaml
+++ b/roles/ks-events/files/kube-events/templates/operator/deploy.yaml
@@ -41,6 +41,7 @@ spec:
           readOnly: true
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
       serviceAccountName: {{ template "kube-events.operator.fullname" . }}
       terminationGracePeriodSeconds: 10
       volumes:

--- a/roles/ks-logging/files/logsidecar-injector/templates/deploy.yaml
+++ b/roles/ks-logging/files/logsidecar-injector/templates/deploy.yaml
@@ -40,6 +40,7 @@ spec:
             mountPath: /etc/logsidecar-injector/config
           - mountPath: /etc/localtime
             name: host-time
+            readOnly: true
       - name: config-reloader
         image: {{ .Values.configReloader.image.repository }}:{{ .Values.configReloader.image.tag }}
         imagePullPolicy: {{ .Values.configReloader.image.pullPolicy }}
@@ -56,3 +57,4 @@ spec:
             mountPath: /etc/logsidecar-injector/config
           - mountPath: /etc/localtime
             name: host-time
+            readOnly: true

--- a/roles/ks-monitor/files/notification-manager/templates/operator.yaml
+++ b/roles/ks-monitor/files/notification-manager/templates/operator.yaml
@@ -50,6 +50,7 @@ spec:
         volumeMounts:
           - mountPath: /etc/localtime
             name: host-time
+            readOnly: true
       volumes:
         - hostPath:
             path: /etc/localtime

--- a/roles/ks-monitor/templates/node-exporter-daemonset.yaml.j2
+++ b/roles/ks-monitor/templates/node-exporter-daemonset.yaml.j2
@@ -45,10 +45,10 @@ spec:
         volumeMounts:
         - mountPath: /host/proc
           name: proc
-          readOnly: false
+          readOnly: true
         - mountPath: /host/sys
           name: sys
-          readOnly: false
+          readOnly: true
         - mountPath: /host/root
           mountPropagation: HostToContainer
           name: root

--- a/roles/ks-network/topology/weave-scope/templates/weave-scope.yaml.j2
+++ b/roles/ks-network/topology/weave-scope/templates/weave-scope.yaml.j2
@@ -351,10 +351,13 @@ items:
               volumeMounts:
                 - name: scope-plugins
                   mountPath: /var/run/scope/plugins
+                  readOnly: true
                 - name: sys-kernel-debug
                   mountPath: /sys/kernel/debug
+                  readOnly: true
                 - name: docker-socket
                   mountPath: /var/run/docker.sock
+                  readOnly: true
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true

--- a/roles/kubeedge/files/kubeedge/kubeedge/templates/deployment_edge_watcher.yaml
+++ b/roles/kubeedge/files/kubeedge/kubeedge/templates/deployment_edge_watcher.yaml
@@ -38,6 +38,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
         - name: config
           mountPath: /etc/edgewatcher/config
       - args:

--- a/roles/kubeedge/files/kubeedge/kubeedge/templates/deployment_kubeedge.yaml
+++ b/roles/kubeedge/files/kubeedge/kubeedge/templates/deployment_kubeedge.yaml
@@ -53,6 +53,7 @@ spec:
           mountPath: /var/lib/kubeedge
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
       restartPolicy: Always
       {{- with .Values.cloudCore.affinity }}
       affinity: {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
Components involved:
ks-installer
node-exporter
kube-auditing-operator
ks-apiserver
ks-console
ks-controller-manager
ks-events-operator
fluentbit-operator
logsidecar-injector
notification-manager-operator
kube-state-metrics
weave-scope-agent
edge-watcher-controller-manager
cloudcore

Signed-off-by: pixiake <guofeng@yunify.com>