### PR TITLE
Improve the image tag name in the makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea
 results
+
+# GitHub Codespaces
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO?=kubespheredev/ks-installer
-TAG:=$(shell git rev-parse --abbrev-ref HEAD)-dev
+TAG:=$(shell git rev-parse --abbrev-ref HEAD | sed -e 's/\//-/g')-dev
 
 build:
 	docker build . --file Dockerfile --tag $(REPO):$(TAG)


### PR DESCRIPTION
See also:

```
codespace ➜ /workspaces/ks-installer (refactor/remove-devops-crd ✗) $ make build
docker build . --file Dockerfile --tag kubespheredev/ks-installer:refactor/remove-devops-crd-dev
invalid argument "kubespheredev/ks-installer:refactor/remove-devops-crd-dev" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
make: *** [Makefile:5: build] Error 125
```

The result with this PR:
```
docker build . --file Dockerfile --tag kubespheredev/ks-installer:refactor-remove-devops-crd-dev
```
