### PR TITLE
Fix failed to enable workspace network isolation

### DIFF
--- a/roles/ks-core/ks-core/files/ks-core/crds/tenant.kubesphere.io_workspacetemplates.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/crds/tenant.kubesphere.io_workspacetemplates.yaml
@@ -42,11 +42,11 @@ spec:
                       items:
                         properties:
                           op:
+                            pattern: ^(add|remove|replace)?$
                             type: string
                           path:
                             type: string
                           value:
-                            type: object
                             x-kubernetes-preserve-unknown-fields: true
                         required:
                         - path


### PR DESCRIPTION
Signed-off-by: hongming <hongming@kubesphere.io>

fix: https://github.com/kubesphere/kubesphere/issues/4147

```
                    clusterOverrides:
                      items:
                        properties:
                          op:
                            pattern: ^(add|remove|replace)?$
                            type: string
                          path:
                            type: string
                          value:
                            type: object
                            x-kubernetes-preserve-unknown-fields: true
```

`type: object`  restricts the type of value, but it can actually be an integer, boolean, object, array, etc. 