### PR TITLE
kubeedge: fix NodeIp when ks-installer resync

### DIFF
--- a/roles/kubeedge/tasks/main.yaml
+++ b/roles/kubeedge/tasks/main.yaml
@@ -5,7 +5,7 @@
     dest: "{{ kubesphere_dir }}/"
 
 - name: KubeEdge | Getting NodeIp
-  shell: "{{ bin_dir }}/kubectl get node -o wide | awk '{if(NR == 2){print $6}}'"
+  shell: "{{ bin_dir }}/kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}' -l '!node-role.kubernetes.io/edge'"
   register: ks_kubeedge_nodeIP
 
 - name: KubeEdge | Creating manifests


### PR DESCRIPTION
After enabled KubeEdge components, once the ks-installer restart, the current cmdline cannot find the correct NodeIP.
For example： 
```
kubectl get node -o wide | awk '{if(NR == 2){print $6}}'
--
1.1.1.1
```
It returns the edgenode internalIP:
```
NAME            STATUS   ROLES                         AGE     VERSION                   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
edgenode-0aou   Ready    agent,edge                    6d21h   v1.19.3-kubeedge-v1.7.0   1.1.1.1        <none>        Ubuntu 18.04.5 LTS   4.15.0-121-generic   docker://20.10.7
edgenode-llvf   Ready    agent,edge                    33d     v1.19.3-kubeedge-v1.7.0   1.1.1.2        <none>        Ubuntu 18.04.5 LTS   4.15.0-121-generic   docker://20.10.6
node1           Ready    control-plane,master,worker   55d     v1.20.4                   192.168.88.6   <none>        Ubuntu 18.04.5 LTS   4.15.0-121-generic   docker://20.10.7
```
Change to the following cmdline to fix it:
```
 kubectl get node -o wide | grep "master" | awk '{if(NR == 1){print $6}}'
192.168.88.6
```