### PR TITLE
Add support for external es using https

### DIFF
--- a/roles/ks-auditing/templates/custom-output-elasticsearch-auditing.yaml.j2
+++ b/roles/ks-auditing/templates/custom-output-elasticsearch-auditing.yaml.j2
@@ -30,3 +30,7 @@ spec:
           name: "elasticsearch-credentials"
 {% endif %}
 {% endif %}
+{% if common.es.externalElasticsearchScheme is defined and common.es.externalElasticsearchScheme == "https" %}
+    tls:
+      verify: false
+{% endif %}

--- a/roles/ks-auditing/templates/custom-output-elasticsearch-auditing.yaml.j2
+++ b/roles/ks-auditing/templates/custom-output-elasticsearch-auditing.yaml.j2
@@ -30,7 +30,7 @@ spec:
           name: "elasticsearch-credentials"
 {% endif %}
 {% endif %}
-{% if common.es.externalElasticsearchScheme is defined and common.es.externalElasticsearchScheme == "https" %}
+{% if common.es.externalElasticsearchProtocol is defined and common.es.externalElasticsearchProtocol == "https" %}
     tls:
       verify: false
 {% endif %}

--- a/roles/ks-core/config/tasks/main.yaml
+++ b/roles/ks-core/config/tasks/main.yaml
@@ -28,21 +28,14 @@
     - devops.sonarqube.externalSonarToken is defined
 
 - block:
-  - name: KubeSphere | Getting es host
-    shell: >
-      {{ bin_dir }}/kubectl get cm -n kubesphere-system kubesphere-config -o jsonpath='{.data.kubesphere\.yaml}' | grep "logging:" -A 2 | grep "host" | awk '{print $2}'
-    register: es_host
-
   - name: KubeSphere | Getting es index prefix
     shell: >
       {{ bin_dir }}/kubectl get cm -n kubesphere-system kubesphere-config -o jsonpath='{.data.kubesphere\.yaml}' | grep "logging:" -A 2 | grep "indexPrefix" | awk '{print $2}'
     register: es_indexPrefix
 
 - set_fact:
-    esHost: "{{ es_host.stdout }}"
     esIndexPrefix: "{{ es_indexPrefix.stdout }}"
   when:
-    - es_host is defined and es_host.stdout is defined and es_host.stdout != ""
     - es_indexPrefix is defined and es_indexPrefix.stdout is defined and es_indexPrefix.stdout != ""
 
 - name: KubeSphere | Getting token

--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -116,10 +116,8 @@ data:
 {% endif %}
 {% if logging.enabled is defined and logging.enabled == true %}
     logging:
-{% if esHost is defined %}
-      host: {{ esHost }}
-{% elif common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}
-      host: http://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
+{% if common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}
+      host: {{ common.es.externalElasticsearchScheme | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
 {% else %}
       host: http://elasticsearch-logging-data.kubesphere-logging-system.svc:9200
 {% endif %}
@@ -137,7 +135,7 @@ data:
 {% if events.enabled is defined and events.enabled == true %}
     events:
 {% if common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}
-      host: http://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
+      host: {{ common.es.externalElasticsearchScheme | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
 {% else %}
       host: http://elasticsearch-logging-data.kubesphere-logging-system.svc:9200
 {% endif %}
@@ -153,7 +151,7 @@ data:
       enable: true
       webhookURL: https://kube-auditing-webhook-svc.kubesphere-logging-system.svc:6443/audit/webhook/event
 {% if common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}
-      host: http://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
+      host: {{ common.es.externalElasticsearchScheme | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
 {% else %}
       host: http://elasticsearch-logging-data.kubesphere-logging-system.svc:9200
 {% endif %}

--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -117,7 +117,7 @@ data:
 {% if logging.enabled is defined and logging.enabled == true %}
     logging:
 {% if common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}
-      host: {{ common.es.externalElasticsearchScheme | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
+      host: {{ common.es.externalElasticsearchProtocol | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
 {% else %}
       host: http://elasticsearch-logging-data.kubesphere-logging-system.svc:9200
 {% endif %}
@@ -135,7 +135,7 @@ data:
 {% if events.enabled is defined and events.enabled == true %}
     events:
 {% if common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}
-      host: {{ common.es.externalElasticsearchScheme | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
+      host: {{ common.es.externalElasticsearchProtocol | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
 {% else %}
       host: http://elasticsearch-logging-data.kubesphere-logging-system.svc:9200
 {% endif %}
@@ -151,7 +151,7 @@ data:
       enable: true
       webhookURL: https://kube-auditing-webhook-svc.kubesphere-logging-system.svc:6443/audit/webhook/event
 {% if common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}
-      host: {{ common.es.externalElasticsearchScheme | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
+      host: {{ common.es.externalElasticsearchProtocol | default(http) }}://{{ common.es.externalElasticsearchUrl }}:{{ common.es.externalElasticsearchPort }}
 {% else %}
       host: http://elasticsearch-logging-data.kubesphere-logging-system.svc:9200
 {% endif %}

--- a/roles/ks-events/templates/custom-output-elasticsearch-events.yaml.j2
+++ b/roles/ks-events/templates/custom-output-elasticsearch-events.yaml.j2
@@ -30,7 +30,7 @@ spec:
           name: "elasticsearch-credentials"
 {% endif %}
 {% endif %}
-{% if common.es.externalElasticsearchScheme is defined and common.es.externalElasticsearchScheme == "https" %}
+{% if common.es.externalElasticsearchProtocol  is defined and common.es.externalElasticsearchProtocol == "https" %}
     tls:
       verify: false
 {% endif %}

--- a/roles/ks-events/templates/custom-output-elasticsearch-events.yaml.j2
+++ b/roles/ks-events/templates/custom-output-elasticsearch-events.yaml.j2
@@ -30,3 +30,7 @@ spec:
           name: "elasticsearch-credentials"
 {% endif %}
 {% endif %}
+{% if common.es.externalElasticsearchScheme is defined and common.es.externalElasticsearchScheme == "https" %}
+    tls:
+      verify: false
+{% endif %}

--- a/roles/ks-logging/templates/custom-output-elasticsearch-logging.yaml.j2
+++ b/roles/ks-logging/templates/custom-output-elasticsearch-logging.yaml.j2
@@ -31,3 +31,7 @@ spec:
     logstashPrefix: "ks-{{ common.es.elkPrefix }}-log"
     logstashFormat: true
     timeKey: "@timestamp"
+{% if common.es.externalElasticsearchScheme is defined and common.es.externalElasticsearchScheme == "https" %}
+    tls:
+      verify: false
+{% endif %}

--- a/roles/ks-logging/templates/custom-output-elasticsearch-logging.yaml.j2
+++ b/roles/ks-logging/templates/custom-output-elasticsearch-logging.yaml.j2
@@ -31,7 +31,7 @@ spec:
     logstashPrefix: "ks-{{ common.es.elkPrefix }}-log"
     logstashFormat: true
     timeKey: "@timestamp"
-{% if common.es.externalElasticsearchScheme is defined and common.es.externalElasticsearchScheme == "https" %}
+{% if common.es.externalElasticsearchProtocol is defined and common.es.externalElasticsearchProtocol == "https" %}
     tls:
       verify: false
 {% endif %}


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

With this pr, it supports to use of an es cluster that enabled HTTPS to store logging, events, and auditing logs.

We can use an external es cluster that enabled HTTPS like this.

```
apiVersion: installer.kubesphere.io/v1alpha1
kind: ClusterConfiguration
metadata:
  name: ks-installer
  namespace: kubesphere-system
spec:
  common:
    es:
      basicAuth:
        enabled: true
        password: R5HN2Ji6ZC9wR4Ifm574l2p0
        username: elastic
      elkPrefix: logstash
      externalElasticsearchPort: "30730"
      externalElasticsearchProtocol: https
      externalElasticsearchUrl: 192.168.0.4
```

