### PR TITLE
kubeedge: upgrade edge watcher tag to v0.1.1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -128,7 +128,7 @@ post_install_job_tag: "v1.19.1"
 cloudcore_repo: "{{ base_repo }}{{ namespace_override | default('kubeedge') }}/cloudcore"
 cloudcore_tag: "v1.7.2"
 edge_watcher_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/edge-watcher"
-edge_watcher_tag: "v0.1.0"
+edge_watcher_tag: "v0.1.1"
 edge_watcher_agent_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/edge-watcher-agent"
 edge_watcher_agent_tag: "v0.1.0"
 

--- a/roles/kubeedge/files/kubeedge/kubeedge/values.yaml
+++ b/roles/kubeedge/files/kubeedge/kubeedge/values.yaml
@@ -50,15 +50,15 @@ edgeWatcher:
             operator: DoesNotExist
   tolerations: []
   controllerManager:
-    repository: "kubespheredev/edge-watcher"
-    tag: "v0.1.0"
+    repository: "kubesphere/edge-watcher"
+    tag: "v0.1.1"
     pullPolicy: "IfNotPresent"
   kubeRBACProxy:
     repository: "kubesphere/kube-rbac-proxy"
     tag: "v0.5.0"
     pullPolicy: "IfNotPresent"
   edgeWatcherAgent:
-    repository: "kubespheredev/edge-watcher-agent"
+    repository: "kubesphere/edge-watcher-agent"
     tag: "v0.1.0"
     pullPolicy: "IfNotPresent"
     affinity:

--- a/scripts/images-list.txt
+++ b/scripts/images-list.txt
@@ -132,7 +132,7 @@ kubespheredev/openpitrix-jobs:v3.1.1
 weaveworks/scope:1.13.0
 ##kubeedge-images
 kubeedge/cloudcore:v1.7.2
-kubesphere/edge-watcher:v0.1.0
+kubesphere/edge-watcher:v0.1.1
 kubesphere/kube-rbac-proxy:v0.5.0
 kubesphere/edge-watcher-agent:v0.1.0
 ##example-images-images


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

fix:
- kubeedge:  upgrade edge watcher to v0.1.1.
- fix kubespheredev to kubesphere.

/cc @pixiake @benjaminhuo 