### PR TITLE
Change devops image tag from master to a variable ks_version

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -151,9 +151,9 @@ snapshot_controller_tag: "v4.0.0"
 
 # ks-devops
 ks_devops_registry: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}"
-ks_devops_controller_tag: "master"
-ks_devops_apiserver_tag: "master"
-ks_devops_tools_tag: "master"
+ks_devops_controller_tag: "{{ ks_version }}"
+ks_devops_apiserver_tag: "{{ ks_version }}"
+ks_devops_tools_tag: "{{ ks_version }}"
 
 #jenkins:
 jenkins_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-jenkins"


### PR DESCRIPTION
it's possible to support nightly build via the variable {{ks_version}}

See the image tags:

![image](https://user-images.githubusercontent.com/1450685/131989396-40b91f77-7b05-443b-8627-c1c832e8b104.png)
![image](https://user-images.githubusercontent.com/1450685/131989423-f5bf5e39-1cd6-4615-a3a5-aea4aab6577d.png)
![image](https://user-images.githubusercontent.com/1450685/131989448-2ea3f461-bcfb-4b8b-ad5e-ccb7df01e077.png)

fix https://github.com/kubesphere/ks-devops/issues/216

/area devops
/cc @kubesphere/sig-devops 