### PR TITLE
support setting host cluster name

### DIFF
--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -107,6 +107,12 @@ data:
 {% if multicluster.proxyPublishAddress is defined and multicluster.proxyPublishAddress != "" %}
       proxyPublishAddress: {{ multicluster.proxyPublishAddress }}
 {% endif %}
+{% if multicluster.clusterControllerResyncPeriod is defined and multicluster.clusterControllerResyncPeriod != "" %}
+      clusterControllerResyncPeriod: {{ multicluster.clusterControllerResyncPeriod }}
+{% endif %}
+{% if multicluster.hostClusterName is defined and multicluster.hostClusterName != "" %}
+      hostClusterName: {{ multicluster.hostClusterName }}
+{% endif %}
 {% endif %}
     monitoring:
 {% if common.monitoring is defined and common.monitoring.endpoint is defined %}


### PR DESCRIPTION
Signed-off-by: yuswift <yuswift2018@gmail.com>
part of https://github.com/kubesphere/kubesphere/pull/4158
we can now set the host cluster name in the cc
```
  multicluster:
    clusterRole: host
    hostClusterName: control-plane
```