### PR TITLE
feat: add gpu kinds to configmap

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -47,7 +47,16 @@ spec:
       # type: external   # Whether to specify the external prometheus stack, and need to modify the endpoint at the next line.
       endpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090 # Prometheus endpoint to get metrics data.
       GPUMonitoring:     # Enable or disable the GPU-related metrics. If you enable this switch but have no GPU resources, Kubesphere will set it to zero. 
-        enabled: false  
+        enabled: false
+    # gpu:                 # Install GPUKinds. The default GPU kind is nvidia.com/gpu. Other GPU kinds can be added here according to your needs. 
+    #   kinds:         
+    #   - resourceName: "nvidia.com/gpu"
+    #     resourceType: "GPU"
+    #     default: true
+    #   - resourceName: "virtaitech.com/gpu"
+    #     resourceType: "GPU"
+    #   - resourceName: "tencent.com/vcuda-core"
+    #     resourceType: "GPU"
     es:   # Storage backend for logging, events and auditing.
       # master:
       #   volumeSize: 4Gi  # The volume size of Elasticsearch master nodes.

--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -125,6 +125,17 @@ data:
 {% else %}
       enableGPUMonitoring: false
 {% endif %}
+{% if common.gpu is defined and common.gpu.kinds is defined %}
+    gpu:
+      kinds: 
+{% for kind in common.gpu.kinds %}
+      - resourceName: {{ kind.resourceName }}
+        resourceType: {{ kind.resourceType }}
+{% if kind.default is defined %}
+        default: {{ kind.default }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if logging.enabled is defined and logging.enabled == true %}
     logging:
 {% if common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

Features:
- add gpu kinds to configmap

Have a definition in cc like follows:
```
common:
  gpu:
    kinds:          # Install GPUKinds. The default GPU kind is nvidia.com/gpu. Other GPU kinds can be added here according to your needs. 
    - resourceName: "nvidia.com/gpu"
      resourceType: "GPU"
      default: true
    - resourceName: "virtaitech.com/gpu"
      resourceType: "GPU"
    - resourceName: "tencent.com/vcuda-core"
      resourceType: "GPU"
```

Will get the configmap kubesphere-config  like follows after finishing installation:
```
gpu:
  kinds:    
  - resourceName: "nvidia.com/gpu"
    resourceType: "GPU"
    default: true
  - resourceName: "virtaitech.com/gpu"
    resourceType: "GPU"
  - resourceName: "tencent.com/vcuda-core"
    resourceType: "GPU"
```

/cc @benjaminhuo @pixiake 