### PR TITLE
[WIP] Support custom components' scheduling

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -18,6 +18,9 @@ spec:
     endpointIps: localhost  # etcd cluster EndpointIps. It can be a bunch of IPs here.
     port: 2379              # etcd port.
     tlsEnable: true
+  affinity: {}
+  tolerations: {}
+  nodeSelector: {}
   common:
     # apiserver:            # Enlarge the apiserver and controller manager's resource requests and limits for the large cluster
     #  resources:

--- a/roles/gatekeeper/templates/custom-values-gatekeeper.yaml.j2
+++ b/roles/gatekeeper/templates/custom-values-gatekeeper.yaml.j2
@@ -10,6 +10,27 @@ controllerManager:
     requests:
       cpu: {{ gatekeeper.controller_manager.resources.resources.cpu | default("100m") }}
       memory: {{ gatekeeper.controller_manager.resources.resources.memory | default("256Mi") }}
+{% if affinity is defined and affinity is not None %}
+  affinity:
+{{ affinity | to_nice_yaml }}
+{% elif gatekeeper.affinity is defined and gatekeeper.affinity is not None %}
+  affinity:
+{{ gatekeeper.affinity | to_nice_yaml }}
+{% else %}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: gatekeeper.sh/operation
+                  operator: In
+                  values:
+                    - webhook
+            topologyKey: kubernetes.io/hostname
+          weight: 100
+{% endif %}
+{% endif %}
 audit:
   resources:
     limits:

--- a/roles/ks-auditing/templates/custom-values.yaml.j2
+++ b/roles/ks-auditing/templates/custom-values.yaml.j2
@@ -14,7 +14,16 @@ operator:
       memory: {{ auditing.operator.resources.requests.memory | default("20Mi") }}
   nodeSelector: {}
   tolerations: []
+{% if affinity is defined and affinity is not None %}
+  affinity:
+{{ affinity | to_nice_yaml }}
+{% elif auditing.affinity is defined and auditing.affinity is not None %}
+  affinity:
+{{ auditing.affinity | to_nice_yaml }}
+{% else %}
   affinity: {}
+{% endif %}
+{% endif %}
 
 
 # value of kube-auditing webhook
@@ -35,7 +44,15 @@ webhook:
       memory: {{ auditing.webhook.resources.requests.memory | default("50Mi") }}
   nodeSelector: {}
   tolerations: []
+{% if affinity is defined and affinity is not None %}
+  affinity:
+{{ affinity | to_nice_yaml }}
+{% elif auditing.affinity is defined and auditing.affinity is not None %}
+  affinity:
+{{ auditing.affinity | to_nice_yaml }}
+{% else %}
   affinity: {}
+{% endif %}
   receivers:
     - name: alert
       type: alertmanager

--- a/roles/ks-core/ks-core/files/ks-core/templates/ks-apiserver.yml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/ks-apiserver.yml
@@ -65,33 +65,18 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 15
       serviceAccountName: {{ include "ks-core.serviceAccountName" . }}
+      {{ - with .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{ - end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{ - with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: In
-                values:
-                - ""
-{{- if gt .Values.replicaCount 1.0 }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - ks-apiserver
-            namespaces:
-            - {{ .Release.Namespace }}
-{{- end }}
+      {{ toYaml . | indent 8 }}
+      {{ - end }}
       volumes:
       - hostPath:
           path: /var/run/docker.sock

--- a/roles/ks-core/ks-core/files/ks-core/templates/ks-console.yml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/ks-console.yml
@@ -49,33 +49,18 @@ spec:
           failureThreshold: 8
       serviceAccount: {{ include "ks-core.serviceAccountName" . }}
       serviceAccountName: {{ include "ks-core.serviceAccountName" . }}
+      {{ - with .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{ - end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{ - with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: In
-                values:
-                - ""
-{{- if gt .Values.replicaCount 1.0 }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - ks-console
-            namespaces:
-            - {{ .Release.Namespace }}
-{{- end }}
+      {{ toYaml . | indent 8 }}
+      {{ - end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/roles/ks-core/ks-core/files/ks-core/templates/ks-controller-manager.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/ks-controller-manager.yaml
@@ -80,33 +80,18 @@ spec:
       {{- if .Values.controller.extraVolumes }}
         {{ toYaml .Values.controller.extraVolumes | nindent 6 }}
       {{- end }}
+      {{ - with .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{ - end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{ - with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: In
-                values:
-                - ""
-{{- if gt .Values.replicaCount 1.0 }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - ks-controller-manager
-            namespaces:
-            - {{ .Release.Namespace }}
-{{- end }}
+      {{ toYaml . | indent 8 }}
+      {{ - end }}
 
 ---
 

--- a/roles/ks-core/ks-core/templates/custom-values-ks-core.yaml.j2
+++ b/roles/ks-core/ks-core/templates/custom-values-ks-core.yaml.j2
@@ -57,3 +57,35 @@ env:
       name: redis-secret
       key: auth
 {% endif %}
+
+affinity:
+{% if affinity is defined and affinity is not None %}
+{{ affinity | to_nice_yaml }}
+{% elif common.core.affinity is defined and common.core.affinity is not None %}
+{{ common.core.affinity | to_nice_yaml }}
+{% else %}
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      preference:
+        matchExpressions:
+        - key: node-role.kubernetes.io/master
+          operator: In
+          values:
+          - ""
+{% if master_num is defined and master_num != "1" %}
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - topologyKey: kubernetes.io/hostname
+      labelSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - ks-apiserver
+      namespaces:
+      - {{ .Release.Namespace }}
+{% endif %}
+{% endif %}
+
+

--- a/roles/ks-events/templates/custom-values-events.yaml.j2
+++ b/roles/ks-events/templates/custom-values-events.yaml.j2
@@ -19,6 +19,16 @@ operator:
   # If true, just clean up cr but not crd
   cleanupAllCustomResources: false
   kubectlImage: {{ ks_kubectl_repo }}:{{ ks_kubectl_tag }}
+{% if affinity is defined and affinity is not None %}
+  affinity:
+{{ affinity | to_nice_yaml }}
+{% elif events.affinity is defined and events.affinity is not None %}
+  affinity:
+{{ events.affinity | to_nice_yaml }}
+{% else %}
+  affinity: {}
+{% endif %}
+{% endif %}
 
 exporter:
   enabled: true
@@ -43,6 +53,16 @@ exporter:
     #     name:
     #     port:
     #     path:
+{% if affinity is defined and affinity is not None %}
+  affinity:
+{{ affinity | to_nice_yaml }}
+{% elif events.affinity is defined and events.affinity is not None %}
+  affinity:
+{{ events.affinity | to_nice_yaml }}
+{% else %}
+  affinity: {}
+{% endif %}
+{% endif %}
 
 ruler:
   enabled: {{ events.ruler.enabled | default(true) }}
@@ -72,6 +92,15 @@ ruler:
     #     name:
     #     port:
     #     path:
+{% if affinity is defined and affinity is not None %}
+  affinity:
+{{ affinity | to_nice_yaml }}
+{% elif events.affinity is defined and events.affinity is not None %}
+  affinity:
+{{ events.affinity | to_nice_yaml }}
+{% else %}
+  affinity: {}
+{% endif %}
 
 rule:
   createDefaults: true

--- a/roles/ks-istio/templates/custom-values-jaeger.yaml.j2
+++ b/roles/ks-istio/templates/custom-values-jaeger.yaml.j2
@@ -31,6 +31,14 @@ nodeSelector: {}
 
 tolerations: []
 
+{% if affinity is defined and affinity is not None %}
+affinity:
+{{ affinity | to_nice_yaml }}
+{% elif servicemesh.affinity is defined and servicemesh.affinity is not None %}
+affinity:
+{{ servicemesh.affinity | to_nice_yaml }}
+{% else %}
 affinity: {}
+{% endif %}
 
 securityContext: {}

--- a/roles/ks-istio/templates/custom-values-kiali.yaml.j2
+++ b/roles/ks-istio/templates/custom-values-kiali.yaml.j2
@@ -9,3 +9,13 @@ image:
 
 # Defines where the operator will look for Kial CR resources. "" means "all namespaces".
 watchNamespace: "istio-system"
+
+{% if affinity is defined and affinity is not None %}
+affinity:
+{{ affinity | to_nice_yaml }}
+{% elif servicemesh.affinity is defined and servicemesh.affinity is not None %}
+affinity:
+{{ servicemesh.affinity | to_nice_yaml }}
+{% else %}
+affinity: {}
+{% endif %}

--- a/roles/ks-logging/files/logsidecar-injector/templates/deploy.yaml
+++ b/roles/ks-logging/files/logsidecar-injector/templates/deploy.yaml
@@ -58,3 +58,15 @@ spec:
           - mountPath: /etc/localtime
             name: host-time
             readOnly: true
+      {{ - with .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{ - end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{ - with .Values.affinity }}
+      affinity:
+      {{ toYaml . | indent 8 }}
+      {{ - end }}

--- a/roles/ks-logging/templates/custom-values-logsidecar-injector.yaml.j2
+++ b/roles/ks-logging/templates/custom-values-logsidecar-injector.yaml.j2
@@ -17,6 +17,16 @@ resources:
     cpu: {{ logging.logsidecar.resources.requests.cpu | default("10m") }}
     memory: {{ logging.logsidecar.resources.requests.memory | default("10Mi") }}
 
+{% if affinity is defined and affinity is not None %}
+affinity:
+{{ affinity | to_nice_yaml }}
+{% elif logging.affinity is defined and logging.affinity is not None %}
+affinity:
+{{ logging.affinity | to_nice_yaml }}
+{% else %}
+affinity: {}
+{% endif %}
+
 configReloader:
   image:
     repository: {{ configmap_reload_repo }}

--- a/roles/ks-multicluster/files/kubefed/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/roles/ks-multicluster/files/kubefed/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -98,6 +98,8 @@ spec:
         {{- toYaml .Values.commonNodeSelector | nindent 8 }}
       tolerations:
         {{- toYaml .Values.commonTolerations | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.commonAffinity | nindent 8 }}
       securityContext:
         runAsUser: 1001
       serviceAccountName: kubefed-admission-webhook

--- a/roles/ks-multicluster/templates/custom-values-kubefed.yaml.j2
+++ b/roles/ks-multicluster/templates/custom-values-kubefed.yaml.j2
@@ -5,6 +5,15 @@
 ## Configuration values for kubefed controllermanager deployment.
 ##
 controllermanager:
+{% if affinity is defined and affinity is not None %}
+  commonAffinity:
+{{ affinity | to_nice_yaml }}
+{% elif multicluster.affinity is defined and multicluster.affinity is not None %}
+  commonAffinity:
+{{ multicluster.affinity | to_nice_yaml }}
+{% else %}
+  commonAffinity: {}
+{% endif %}
   controller:
     annotations: {}
 {% if nodeNum is defined and nodeNum < 3 %}

--- a/roles/metrics-server/templates/metrics-server.yaml.j2
+++ b/roles/metrics-server/templates/metrics-server.yaml.j2
@@ -165,6 +165,15 @@ spec:
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
+{% if affinity is defined and affinity is not None %}
+      affinity:
+{{ affinity | to_nice_yaml }}
+{% elif metrics_server.affinity is defined and metrics_server.affinity is not None %}
+      affinity:
+{{ metrics_server.affinity | to_nice_yaml }}
+{% else %}
+      affinity: {}
+{% endif %}
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       volumes:


### PR DESCRIPTION
Supports configuring global or individual custom scheduling policies for components.

Expose `affinity` /  `tolerations` / `nodeSelector` as configurable items for each component

example:
```
  auditing: 
    enabled: false 
    affinity: {}
    tolerations: {}
    nodeSelector: {}
    operator:
      resources: {}
    webhook:
      resources: {}
```







Signed-off-by: pixiake <guofeng@yunify.com>