### PR TITLE
add notification-manager svc endpoint

### DIFF
--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -136,6 +136,12 @@ data:
 {% endif %}
 {% endfor %}
 {% endif %}
+    notification:
+{% if common.notification is defined and common.notification.endpoint is defined %}
+      endpoint: {{ common.notification.endpoint }}
+{% else %}
+      endpoint: http://notification-manager-svc.kubesphere-monitoring-system.svc:19093
+{% endif %}
 {% if logging.enabled is defined and logging.enabled == true %}
     logging:
 {% if common.es.externalElasticsearchUrl is defined and common.es.externalElasticsearchPort is defined and common.es.externalElasticsearchUrl != "" and common.es.externalElasticsearchPort != "" %}

--- a/roles/ks-core/ks-core/files/ks-core/templates/kubesphere-config.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/kubesphere-config.yaml
@@ -24,6 +24,8 @@ data:
 {{- end }}
     monitoring:
       endpoint: {{ .Values.config.monitoring.endpoint | default "http://prometheus-operated.kubesphere-monitoring-system.svc:9090" }}
+    notification:
+      endpoint: {{ .Values.config.notification.endpoint | default "http://notification-manager-svc.kubesphere-monitoring-system.svc:19093" }}
 
     {{- with .Values.config.servicemesh }}
     servicemesh:

--- a/roles/ks-core/ks-core/files/ks-core/values.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/values.yaml
@@ -43,6 +43,7 @@ config:
   jwtSecret: ""
   multicluster: {}
   monitoring: {}
+  notification: {}
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Synchronize with kubesphere-config in kubesphere. https://github.com/kubesphere/kubesphere/blob/master/config/ks-core/templates/kubesphere-config.yaml#L27
 Expose the endpoint of notification-manager. svc

Signed-off-by: wenchajun <dehaocheng@yunify.com>