### PR TITLE
Enable gateway featrue and sync ks-core chart

### DIFF
--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -200,6 +200,15 @@ data:
     kubeedge:
       endpoint: http://edge-watcher.kubeedge.svc/api/
 {% endif %}
+
+    gateway:
+      watchesPath: /var/helm-charts/watches.yaml
+{% if gateway is defined and gateway.namespace is defined %}
+      namespace: {{ gateway.namespace }}
+{% else %}
+      namespace: kubesphere-controls-system
+{% endif %}
+
 kind: ConfigMap
 metadata:
   name: kubesphere-config

--- a/roles/ks-core/ks-core/files/ks-core/crds/gateway.kubesphere.io_gateways.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/crds/gateway.kubesphere.io_gateways.yaml
@@ -1,0 +1,95 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: gateways.gateway.kubesphere.io
+spec:
+  group: gateway.kubesphere.io
+  names:
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Gateway is the Schema for the gateways API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GatewaySpec defines the desired state of Gateway
+            properties:
+              controller:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  replicas:
+                    format: int32
+                    type: integer
+                  scope:
+                    properties:
+                      enabled:
+                        type: boolean
+                      namespace:
+                        type: string
+                    type: object
+                type: object
+              deployment:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  replicas:
+                    format: int32
+                    type: integer
+                type: object
+              service:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  type:
+                    description: Service Type string describes ingress methods for
+                      a service
+                    type: string
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/roles/ks-core/ks-core/files/ks-core/crds/gateway.kubesphere.io_nginxes.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/crds/gateway.kubesphere.io_nginxes.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nginxes.gateway.kubesphere.io
+spec:
+  group: gateway.kubesphere.io
+  names:
+    kind: Nginx
+    listKind: NginxList
+    plural: nginxes
+    singular: nginx
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Nginx is the Schema for the nginxes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Nginx
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of Nginx
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
This PR adds gateway configuration to the `kubesphere-config.yaml` config file and enables the feature by default. 

### Which issue(s) this PR fixes:
Fixes kubesphere/kubesphere#3055 

/cc @kubesphere/sig-installation 

