### PR TITLE
revert GPU kinds

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -48,15 +48,11 @@ spec:
       endpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090 # Prometheus endpoint to get metrics data.
       GPUMonitoring:     # Enable or disable the GPU-related metrics. If you enable this switch but have no GPU resources, Kubesphere will set it to zero. 
         enabled: false
-    # gpu:                 # Install GPUKinds. The default GPU kind is nvidia.com/gpu. Other GPU kinds can be added here according to your needs. 
-    #   kinds:         
-    #   - resourceName: "nvidia.com/gpu"
-    #     resourceType: "GPU"
-    #     default: true
-    #   - resourceName: "virtaitech.com/gpu"
-    #     resourceType: "GPU"
-    #   - resourceName: "tencent.com/vcuda-core"
-    #     resourceType: "GPU"
+    gpu:                 # Install GPUKinds. The default GPU kind is nvidia.com/gpu. Other GPU kinds can be added here according to your needs. 
+      kinds:         
+      - resourceName: "nvidia.com/gpu"
+        resourceType: "GPU"
+        default: true
     es:   # Storage backend for logging, events and auditing.
       # master:
       #   volumeSize: 4Gi  # The volume size of Elasticsearch master nodes.


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

Currently, only support GPU Kind nvidia.com/gpu. 

Related pr https://github.com/kubesphere/ks-installer/pull/1671


/cc @benjaminhuo 