### PR TITLE
Remove extra spaces from the kubesphere-config

### DIFF
--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -139,7 +139,7 @@ data:
 {% endif %}
 {% if common.gpu is defined and common.gpu.kinds is defined %}
     gpu:
-      kinds: 
+      kinds:
 {% for kind in common.gpu.kinds %}
       - resourceName: {{ kind.resourceName }}
         resourceType: {{ kind.resourceType }}


### PR DESCRIPTION
Extra spaces can cause layout disorder of kubesphere-config.


Signed-off-by: pixiake <guofeng@yunify.com>