### PR TITLE
fix clerical error: FluentBit ConfigMap

### DIFF
--- a/roles/common/files/fluentbit-operator/init/fluentbit-operator-configmap.yaml
+++ b/roles/common/files/fluentbit-operator/init/fluentbit-operator-configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  systemd.lua: |2
+  systemd.lua: |
     function add_time(tag, timestamp, record)
       new_record = {}
       timeStr = os.date("!*t", timestamp["sec"])


### PR DESCRIPTION
Compared with FluentBit Official([configuration](https://github.com/fluent/fluentbit-operator/blob/master/manifests/logging-stack/systemd-lua-config.yaml)), I think it's an error in ks-installer.