### PR TITLE
Fix the issue of invalid password after enable redis

### DIFF
--- a/roles/ks-core/meta/main.yaml
+++ b/roles/ks-core/meta/main.yaml
@@ -4,8 +4,6 @@ dependencies:
   - role: ks-core/init-token
 
   - role: ks-core/ks-core
-    when:
-      - "status.core is not defined or status.core.status is not defined or status.core.status != 'enabled'"
 
 # data should be initialed after ks-core installed
   - role: ks-core/prepare


### PR DESCRIPTION

<img width="945" alt="7f64e108aa80478e929781b1bffa893" src="https://user-images.githubusercontent.com/22290449/133884044-235ee646-a77c-4d03-835f-8c558ef50c48.png">

This issue is caused by not updating the configuration of ks-core after the cluster is existed.



Signed-off-by: pixiake <guofeng@yunify.com>