### PR TITLE
Remove unnecessary tag override

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -156,8 +156,8 @@ ks_devops_apiserver_tag: "{{ ks_version }}"
 ks_devops_tools_tag: "{{ ks_version }}"
 
 #jenkins:
-jenkins_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-jenkins"
-jenkins_tag: 3.2.0-rc0-2.249.1
+jenkins_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/ks-jenkins"
+jenkins_tag: 2.249.1
 jnlp_slave_repo: "{{ base_repo }}{{ namespace_override | default('jenkins') }}/jnlp-slave"
 jnlp_slave_tag: 3.27-1
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -157,7 +157,7 @@ ks_devops_tools_tag: "{{ ks_version }}"
 
 #jenkins:
 jenkins_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/ks-jenkins"
-jenkins_tag: 2.249.1
+jenkins_tag: 3.2.0-rc0-2.249.1
 jnlp_slave_repo: "{{ base_repo }}{{ namespace_override | default('jenkins') }}/jnlp-slave"
 jnlp_slave_tag: 3.27-1
 

--- a/roles/ks-devops/templates/ks-devops-values.yaml.j2
+++ b/roles/ks-devops/templates/ks-devops-values.yaml.j2
@@ -4,12 +4,6 @@
 image:
   # support 'ghcr.io/kubesphere-sigs' or 'kubespheresig'
   registry: "{{ ks_devops_registry }}"
-  controller:
-    tag: "{{ ks_devops_controller_tag }}"
-  apiserver:
-    tag: "{{ ks_devops_apiserver_tag }}"
-  tools:
-    tag: "{{ ks_devops_tools_tag }}"
   pullPolicy: {{ ks_image_pull_policy }}
 
 authentication:
@@ -23,73 +17,6 @@ serviceAccount:
 s2i:
   image:
     registry: "{{ s2i_registry }}"
-  # Binary image
-  binary:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-
-  # Java image
-  java8CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  java8Runtime:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-
-  java11CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-
-  java11Runtime:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-
-  # Nodejs image
-  nodejs8CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  nodejs6CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  nodejs4CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-
-  # Python image
-  python36CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  python35CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  python34CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  python27CentOs7:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-
-  # Tomcat image
-  tomcat85Java11:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  tomcat85Java11Runtime:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  tomcat85Java8:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-  tomcat85Java8Runtime:
-    image:
-      tag: "{{ s2itemplates_tag }}"
-
-  s2irun:
-    image:
-      tag: "{{ s2irun_tag }}"
-
-  s2ioperator:
-    image:
-      tag: "{{ s2ioperator_tag }}"
   prometheus:
     namespace: "kubesphere-monitoring-system"
 
@@ -99,7 +26,6 @@ jenkins:
     enabled: true
   Master:
     Image: "{{ jenkins_repo }}"
-    ImageTag: "{{ jenkins_tag }}"
     ImagePullPolicy: {{ ks_image_pull_policy }}
     resources:
       requests:
@@ -111,20 +37,8 @@ jenkins:
     JavaOpts: "{{ JavaOpts }}"
   Agent:
     Image: "{{ jnlp_slave_repo }}"
-    ImageTag: "{{ jnlp_slave_tag }}"
     Builder:
       Registry: "{{ builder_registry }}"
-      Base:
-        Tag: "{{ builder_base_tag }}"
-      NodeJs:
-        Image: builder-nodejs
-        Tag: "{{ builder_nodejs_tag }}"
-      Maven:
-        Image: builder-maven
-        Tag: "{{ builder_maven_tag }}"
-      Golang:
-        Image: builder-go
-        Tag: "{{ builder_go_tag }}"
   securityRealm:
     type: ldap
     ldap:


### PR DESCRIPTION
### What this PR dose

- Change default value of `jenkins_repo` to `kubespheredev`
- Remove unnecessary tag override

### Why we need it

For first action, please see also <https://github.com/kubesphere/ks-devops/issues/253>.

Then, in fact, the ansible variables defined in download tasks are not directly related to ks-devops tasks. So I removed the some values in `roles/ks-devops/templates/ks-devops-values.yaml.j2`. Any changes of tag will be in <https://github.com/kubesphere-sigs/ks-devops-helm-chart>.

### Which issue(s) this PR fixes

- Fix https://github.com/kubesphere/ks-devops/issues/253

/kind chore
