### PR TITLE
create builtin repo when installing app store

### DIFF
--- a/deploy/kubesphere-installer.yaml
+++ b/deploy/kubesphere-installer.yaml
@@ -244,6 +244,13 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - application.kubesphere.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
 
 ---
 kind: ClusterRoleBinding

--- a/roles/openpitrix/tasks/main.yaml
+++ b/roles/openpitrix/tasks/main.yaml
@@ -11,6 +11,7 @@
     dest: "{{ kubesphere_dir }}/{{ item.path }}/{{ item.file }}"
   with_items:
     - { path: openpitrix, file: ks-openpitrix-import.yaml }
+    - { path: openpitrix, file: builtin-repo.yaml }
 
 - name: OpenPitrix | Check OpenPitrix v3.0.0
   shell: >
@@ -37,3 +38,16 @@
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/openpitrix/ks-openpitrix-import.yaml
   when:
     - openpitrix_deploy_count.stdout == "0"
+
+- name: OpenPitrix | Check whether builtin repo exists
+  shell: >
+    {{ bin_dir }}/kubectl get hrepo builtin-stable -oname
+  register: builtin_repo_output
+  failed_when: false
+
+- name: OpenPitrix | Create builtin repo
+  shell: >
+    {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/openpitrix/builtin-repo.yaml
+  when:
+    - builtin_repo_output.stdout is not defined or builtin_repo_output.stdout == ""
+

--- a/roles/openpitrix/templates/builtin-repo.yaml.j2
+++ b/roles/openpitrix/templates/builtin-repo.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: application.kubesphere.io/v1alpha1
+kind: HelmRepo
+metadata:
+  annotations:
+    app.kubesphere.io/sync-period: "3600s"
+    kubesphere.io/creator: admin
+  labels:
+    kubesphere.io/workspace: system-workspace
+  name: builtin-stable
+spec:
+  credential: {}
+  name: built-stable
+  syncPeriod: 3600
+  url: https://charts.kubesphere.io/stable


### PR DESCRIPTION
Create built-in repo when installing the app store. So kubesphere will load this repo into memory and return these apps to the console.