### PR TITLE
Fix the nightly tag of ks-devops apiserver,controller and tools

### DIFF
--- a/roles/ks-devops/templates/ks-devops-values.yaml.j2
+++ b/roles/ks-devops/templates/ks-devops-values.yaml.j2
@@ -5,6 +5,12 @@ image:
   # support 'ghcr.io/kubesphere-sigs' or 'kubespheresig'
   registry: "{{ ks_devops_registry }}"
   pullPolicy: {{ ks_image_pull_policy }}
+  controller:
+    tag: "{{ ks_devops_controller_tag }}"
+  apiserver:
+    tag: "{{ ks_devops_apiserver_tag }}"
+  tools:
+    tag: "{{ ks_devops_tools_tag }}"
 
 authentication:
   # If not set, jwt tools will generate and set it automatically


### PR DESCRIPTION
this issue caused by https://github.com/kubesphere/ks-installer/pull/1703

See the following screenshot:

![image](https://user-images.githubusercontent.com/1450685/134840162-7be09cde-ef57-46bd-b592-42c7790ed227.png)

/area devops