### PR TITLE
fix ks-installer deployment sample image tag

### DIFF
--- a/deploy/kubesphere-installer.yaml
+++ b/deploy/kubesphere-installer.yaml
@@ -287,7 +287,7 @@ spec:
       serviceAccountName: ks-installer
       containers:
       - name: installer
-        image: kubespheredev/ks-installer:latest
+        image: kubespheredev/ks-installer:master
         imagePullPolicy: "Always"
         resources:
           limits:


### PR DESCRIPTION
`ks-installer` yaml under deploy still uses `latest` tag, change it to `master`