### PR TITLE
Update volume size detection method

### DIFF
--- a/controller/installRunner.py
+++ b/controller/installRunner.py
@@ -477,17 +477,21 @@ def generate_new_cluster_configuration(api):
         if "redisVolumSize" in cluster_configuration_spec["common"]:
             cluster_configuration_spec["common"]["redis"][
                 "volumeSize"] = cluster_configuration_spec["common"]["redisVolumSize"]
-
+            del cluster_configuration_spec["common"]["redisVolumSize"]
         if "openldapVolumeSize" in cluster_configuration_spec["common"]:
             cluster_configuration_spec["common"]["openldap"][
                 "volumeSize"] = cluster_configuration_spec["common"]["openldapVolumeSize"]
-
+            del cluster_configuration_spec["common"]["openldapVolumeSize"]
         if "minio" not in cluster_configuration_spec["common"]:
-            cluster_configuration_spec["common"]["minio"] = {
-                "volumeSize": cluster_configuration_spec["common"]["minioVolumeSize"]
-            }
-        if "minioVolumeSize" in cluster_configuration_spec["common"]:
-            cluster_configuration_spec["common"]["minio"]["volumeSize"] = cluster_configuration_spec["common"]["minioVolumeSize"]
+            if "minioVolumeSize" in cluster_configuration_spec["common"]:
+                cluster_configuration_spec["common"]["minio"] = {
+                    "volumeSize": cluster_configuration_spec["common"]["minioVolumeSize"]
+                }
+                del cluster_configuration_spec["common"]["minioVolumeSize"]
+        else:
+            if "minioVolumeSize" in cluster_configuration_spec["common"]:
+                cluster_configuration_spec["common"]["minio"]["volumeSize"] = cluster_configuration_spec["common"]["minioVolumeSize"]
+                del cluster_configuration_spec["common"]["minioVolumeSize"]
 
         # Migrate the configuration of es elasticsearch
         if "es" in cluster_configuration_spec["common"]:

--- a/roles/common/tasks/get_old_config.yaml
+++ b/roles/common/tasks/get_old_config.yaml
@@ -2,7 +2,7 @@
 
 - name: KubeSphere | Checking mysql PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-system mysql-pvc -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-system mysql-pvc -o jsonpath='{.spec.resources.requests.storage}'
   register: mysql_db_pvc
   failed_when: false
 
@@ -16,7 +16,7 @@
 
 - name: KubeSphere | Checking redis PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-system redis-pvc -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-system redis-pvc -o jsonpath='{.spec.resources.requests.storage}'
   register: redis_db_pvc
   failed_when: false
 
@@ -30,7 +30,7 @@
 
 - name: KubeSphere | Checking minio PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-system minio -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-system minio -o jsonpath='{.spec.resources.requests.storage}'
   register: minio_storage_pvc
   failed_when: false
 
@@ -44,7 +44,7 @@
 
 - name: KubeSphere | Checking openldap PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-system openldap-pvc-openldap-0 -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-system openldap-pvc-openldap-0 -o jsonpath='{.spec.resources.requests.storage}'
   register: openldap_db_pvc
   failed_when: false
 
@@ -58,7 +58,7 @@
 
 - name: KubeSphere | Checking etcd db PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-system etcd-pvc -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-system etcd-pvc -o jsonpath='{.spec.resources.requests.storage}'
   register: etcd_db_pvc
   failed_when: false
 
@@ -72,7 +72,7 @@
 
 - name: KubeSphere | Checking redis ha PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-system data-redis-ha-server-0 -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-system data-redis-ha-server-0 -o jsonpath='{.spec.resources.requests.storage}'
   register: redis_ha_pvc
   failed_when: false
 
@@ -86,7 +86,7 @@
 
 - name: KubeSphere | Checking es-master PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-logging-system data-elasticsearch-logging-discovery-0 -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-logging-system data-elasticsearch-logging-discovery-0 -o jsonpath='{.spec.resources.requests.storage}'
   register: es_master_pvc
   failed_when: false
 
@@ -100,7 +100,7 @@
 
 - name: KubeSphere | Checking es data PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-logging-system data-elasticsearch-logging-data-0 -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-logging-system data-elasticsearch-logging-data-0 -o jsonpath='{.spec.resources.requests.storage}'
   register: es_data_pvc
   failed_when: false
 

--- a/roles/ks-devops/tasks/get_old_config.yaml
+++ b/roles/ks-devops/tasks/get_old_config.yaml
@@ -50,7 +50,7 @@
 
 - name: ks-devops | Checking Jenkins PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-devops-system ks-jenkins -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-devops-system ks-jenkins -o jsonpath='{.spec.resources.requests.storage}'
   register: jenkins_pvc
   failed_when: false
 

--- a/roles/ks-monitor/tasks/get_old_config.yaml
+++ b/roles/ks-monitor/tasks/get_old_config.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Monitoring | Checking Prometheus PersistentVolumeClaim
   shell: >
-    {{ bin_dir }}/kubectl get pvc -n kubesphere-monitoring-system prometheus-k8s-db-prometheus-k8s-0 -o jsonpath='{.status.capacity.storage}'
+    {{ bin_dir }}/kubectl get pvc -n kubesphere-monitoring-system prometheus-k8s-db-prometheus-k8s-0 -o jsonpath='{.spec.resources.requests.storage}'
   register: prometheus_pvc
   failed_when: false
 


### PR DESCRIPTION
`.status.capacity.storage` is the actual persistent storage disk size.
`.spec.resources.requests.storage` is the requested persistent storage disk size.

Some storage plugin generated persistent volumes that do not match the requested size, so the `.spec.resources.requests.storage' should be filled with the existing `.spec.resources.requests.storage` when upgrading.

`.status.capacity.storage` --> `.spec.resources.requests.storage`

Signed-off-by: pixiake <guofeng@yunify.com>