### PR TITLE
Avoid repeated creation of admin user

### DIFF
--- a/roles/ks-core/ks-core/files/ks-core/templates/account.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/account.yaml
@@ -1,3 +1,4 @@
+{{ if not (lookup "iam.kubesphere.io/v1alpha2" "User" "" "admin") -}}
 ---
 apiVersion: iam.kubesphere.io/v1alpha2
 kind: User
@@ -11,3 +12,4 @@ spec:
   password: "{{ include "getOrDefaultPass" (dict "Name" "admin" "Default" "$2a$10$zcHepmzfKPoxCVCYZr5K7ORPZZ/ySe9p/7IUb/8u./xHrnSX2LOCO") }}"
 status:
   state: Active
+{{ end -}}


### PR DESCRIPTION
The webhook connect refused, which may cause the repeated creation of admin to fail.

![image](https://user-images.githubusercontent.com/22290449/135400304-eb1152d6-0a9d-46b6-b33f-a2f2559d830b.png)


Signed-off-by: pixiake <guofeng@yunify.com>