### PR TITLE
Allows to override nginx ingress controller image in kubesphere config

### DIFF
--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -221,6 +221,8 @@ data:
 
     gateway:
       watchesPath: /var/helm-charts/watches.yaml
+      repository: {{ nginx_ingress_controller_repo }}
+      tag: {{ nginx_ingress_controller_tag }}
 {% if gateway is defined and gateway.namespace is defined %}
       namespace: {{ gateway.namespace }}
 {% else %}


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
When deploymnet kubesphere offline. the all the docker image will be changed to a local repo. So all the docker image need to be configuralbe. 

