### PR TITLE
Make DevOps agent runnable on containerd environment properly

### DIFF
--- a/roles/ks-devops/tasks/main.yaml
+++ b/roles/ks-devops/tasks/main.yaml
@@ -80,6 +80,15 @@
 - name: ks-devops | Getting name of existing PVC named ks-jenkins
   set_fact: 
     KS_JENKINS_PVC: "{{ ks_jenkins_pvc.stdout }}"
+  
+- name: ks-devops | Getting Kubernetes Node info
+  shell: |
+    kubectl get node -ojson | jq '.items[0].status.nodeInfo.containerRuntimeVersion'
+  register: container_runtime
+
+- name: ks-devops | Setting container runtime of agent builder
+  set_fact:
+    builder_container_runtime: "{{ container_runtime.stdout is search('docker://') | ternary('docker', 'podman') }}"
 
 - name: ks-devops | Creating manifests
   template:

--- a/roles/ks-devops/templates/ks-devops-values.yaml.j2
+++ b/roles/ks-devops/templates/ks-devops-values.yaml.j2
@@ -81,6 +81,7 @@ jenkins:
     Image: "{{ jnlp_slave_repo }}"
     Builder:
       Registry: "{{ builder_registry }}"
+      ContainerRuntime: "{{ builder_container_runtime }}"
   securityRealm:
     type: ldap
     ldap:


### PR DESCRIPTION
### What this PR dose?

Determine container runtime by getting Kubernetes node info and set it to helm charts' values of ks-devops.

### Why we need it?

At present, we have fully support containerd container runtime now, please see also https://github.com/kubesphere/ks-devops/issues/67.

Even we could change [values of helm charts](https://github.com/kubesphere-sigs/ks-devops-helm-chart/tree/master/charts/ks-devops#dockerless) to support containerd, but there is no way to set helm charts' values in ks-installer.

As a result, I fire this pull request to make DevOps agent runnable on containerd environment properly.

### How to test it?

Docker images for test: `johnniang/ks-installer:devops-in-containerd`

1. Install KubeSphere via any way on `containerd` container runtime
2. Replace container image of Deployment `ks-installer`
    > Please note that don't enable DevOps application before replacing
3. Enable DevOps application
    ```bash
    kubectl patch -nkubesphere-system cc ks-installer --type=json -p='[{"op": "replace", "path": "/spec/devops/enabled", "value": true}]'
    ```
4. Wait for a complete restart and check ConfigMap `jenkins-casc-config`
    ![image](https://user-images.githubusercontent.com/16865714/141611284-00c3c428-2f4d-4370-a843-6e40f4f3fa4f.png)
5. Run a Pipeline to verify the podman works well
	```groovy
	pipeline {
		agent {
			label 'base'
		}
		
		stages {
			stage('Print Podman version') {
			steps {
				container('base') {
				sh '''
				podman version
				podman pull halohub/halo
				'''
				}
			}
			}
		}
	}
	```

/kind feature
/cc @kubesphere/sig-installation 
/cc @kubesphere/sig-devops 