### PR TITLE
Fix kubefed's kubectl image cannot be managed by ks-installer

### DIFF
--- a/roles/ks-multicluster/templates/custom-values-kubefed.yaml.j2
+++ b/roles/ks-multicluster/templates/custom-values-kubefed.yaml.j2
@@ -43,7 +43,7 @@ controllermanager:
     repository: {{ kubefed_repo }}
     image: {{ kubefed_image }}
     tag: {{ kubefed_image_tag }}
-  postInstallJob::
+  postInstallJob:
     repository: {{ post_install_job_repo }}
     image: {{ post_install_job_image }}
     tag: {{ post_install_job_tag }}


### PR DESCRIPTION
As the title …

Signed-off-by: pixiake <guofeng@yunify.com>