### PR TITLE
Adjust default xmx/xms configuration

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -53,8 +53,8 @@ spec:
     jenkinsMemoryLim: 2Gi      # Jenkins memory limit.
     jenkinsMemoryReq: 1500Mi   # Jenkins memory request.
     jenkinsVolumeSize: 8Gi     # Jenkins volume size.
-    jenkinsJavaOpts_Xms: 512m  # The following three fields are JVM parameters.
-    jenkinsJavaOpts_Xmx: 512m
+    jenkinsJavaOpts_Xms: 1200m  # The following three fields are JVM parameters.
+    jenkinsJavaOpts_Xmx: 1600m
     jenkinsJavaOpts_MaxRAM: 2g
   events:                  # Whether to install KubeSphere events system. It provides a graphical web console for Kubernetes Events exporting, filtering and alerting in multi-tenant Kubernetes clusters.
     enabled: false


### PR DESCRIPTION
Signed-off-by: Daniel Hu <farmer.hutao@outlook.com>

The jvm heap memory configuration should maintain about 70-80% of the k8s resource request/limit. Too high is easy to oom, and too low will cause memory waste.

see also: https://akobor.me/posts/heap-size-and-resource-limits-in-kubernetes-for-jvm-applications