### PR TITLE
Remove the default ingress for kiali and jaeger

### DIFF
--- a/roles/ks-istio/templates/jaeger-cr.yaml.j2
+++ b/roles/ks-istio/templates/jaeger-cr.yaml.j2
@@ -4,6 +4,8 @@ metadata:
   name: jaeger
   namespace: istio-system
 spec:
+  ingress:
+    enabled: false
   agent:
     image: {{ jaeger_agent_repo }}:{{ jaeger_agent_tag }}
   collector:

--- a/roles/ks-istio/templates/kiali-cr.yaml.j2
+++ b/roles/ks-istio/templates/kiali-cr.yaml.j2
@@ -15,6 +15,7 @@ spec:
     image_version: "{{ kiali_tag }}"
     namespace: "istio-system"
     service_type: "ClusterIP"
+    ingress_enabled: false
   external_services:
     prometheus:
       url: http://prometheus-k8s.kubesphere-monitoring-system:9090


### PR DESCRIPTION
Remove the default ingress for kiali and jaeger. Otherwise, those ingresses will be served by the Cluster gateway。
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>