### PR TITLE
Multiple components use the same kubectl image

### DIFF
--- a/controller/installRunner.py
+++ b/controller/installRunner.py
@@ -418,6 +418,7 @@ def generateConfig(api):
     nodesObj = json.loads(nodesStr)
 
     cluster_config['nodeNum'] = len(nodesObj["items"])
+    cluster_config['kubernetes_version'] = client.VersionApi().get_code().git_version
 
     try:
         with open(configFile, 'w', encoding='utf-8') as f:

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -47,7 +47,7 @@
 
     - name: KubeSphere | Updating snapshot crd
       command: >
-        {% if kubernetes_version.stdout is version('v1.19.0', '>=') %}
+        {% if kubernetes_version is version('v1.19.0', '>=') %}
         {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshot.yaml --force
         {% else %}
         {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshot_before119.yaml --force
@@ -63,7 +63,7 @@
       failed_when: false
 
   when:
-    - kubernetes_version.stdout is version('v1.17.0', '>=')
+    - kubernetes_version is version('v1.17.0', '>=')
 
 
 - name: KubeSphere | Checking openpitrix common component

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -40,7 +40,7 @@ ks_alerting_migration_tag: "v3.1.0"
 ks_console_repo: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}/ks-console"
 ks_console_tag: "{{ ks_version }}"
 ks_kubectl_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/kubectl"
-ks_kubectl_tag: v1.0.0
+ks_kubectl_tag: v1.22.0
 # kubectl versions
 ks_kubectl_versions:
   v1.22.0: v1.22.0
@@ -67,7 +67,7 @@ tower_image: tower
 tower_image_tag: "v0.2.0"
 post_install_job_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}"
 post_install_job_image: kubectl
-post_install_job_tag: "v1.19.1"
+# post_install_job_tag: "v1.19.1"
 
 # kubeedge
 cloudcore_repo: "{{ base_repo }}{{ namespace_override | default('kubeedge') }}/cloudcore"

--- a/roles/ks-core/config/tasks/main.yaml
+++ b/roles/ks-core/config/tasks/main.yaml
@@ -48,25 +48,25 @@
     {{ bin_dir }}/kubectl get secret kubesphere-secret -o jsonpath='{.data.secret}' | base64 -d
   register: ks_secret_str
 
-- name: KubeSphere | Checking Kubernetes version
-  shell: >
-    {{ bin_dir }}/kubectl version -o json | jq '.serverVersion.gitVersion' | sed s/\"//g
-  register: kubernetes_version
+#- name: KubeSphere | Checking Kubernetes version
+#  shell: >
+#    {{ bin_dir }}/kubectl version -o json | jq '.serverVersion.gitVersion' | sed s/\"//g
+#  register: kubernetes_version
 
 - debug:
-    msg: Current Kubernetes version is {{kubernetes_version.stdout}}
+    msg: Current Kubernetes version is {{ kubernetes_version }}
 
 # Get the matched kubectl image
 - name: KubeSphere | Setting kubectl image version
   set_fact:
-    ks_kubectl_tag: "{{item.value}}"
+    ks_kubectl_tag: "{{ item.value }}"
     kubectl_break: true
   loop: "{{ query('dict', ks_kubectl_versions) }}"
   when:
-    - kubectl_break is undefined and kubernetes_version is defined and kubernetes_version.stdout is version(item.key, '>=')
+    - kubectl_break is undefined and kubernetes_version is defined and kubernetes_version is version(item.key, '>=')
 
 - debug:
-    msg: Current kubectl image version is {{ks_kubectl_tag}}
+    msg: Current kubectl image version is {{ ks_kubectl_tag }}
 
 - name: KubeSphere | Getting Kubernetes master num
   shell: >

--- a/roles/ks-core/ks-core/tasks/main.yaml
+++ b/roles/ks-core/ks-core/tasks/main.yaml
@@ -1,16 +1,16 @@
 ---
 
 
-- name: KubeSphere | Getting Kubernetes version
-  shell: >
-    {{ bin_dir }}/kubectl version -o json | jq -r '.serverVersion.gitVersion'
-  register: kubernetes_version
-  failed_when: false
+#- name: KubeSphere | Getting Kubernetes version
+#  shell: >
+#    {{ bin_dir }}/kubectl version -o json | jq -r '.serverVersion.gitVersion'
+#  register: kubernetes_version
+#  failed_when: false
 
 
 - name: KubeSphere | Setting Kubernetes version
   set_fact:
-    kube_version: "{{ kubernetes_version.stdout }}"
+    kube_version: "{{ kubernetes_version }}"
   failed_when: false
 
 

--- a/roles/ks-events/tasks/main.yaml
+++ b/roles/ks-events/tasks/main.yaml
@@ -5,6 +5,21 @@
     src: "kube-events"
     dest: "{{ kubesphere_dir }}/ks-events/"
 
+- debug:
+    msg: Current Kubernetes version is {{ kubernetes_version }}
+
+# Get the matched kubectl image
+- name: KubeSphere | Setting kubectl image version
+  set_fact:
+    ks_kubectl_tag: "{{ item.value }}"
+    kubectl_break: true
+  loop: "{{ query('dict', ks_kubectl_versions) }}"
+  when:
+    - kubectl_break is undefined and kubernetes_version is defined and kubernetes_version is version(item.key, '>=')
+
+- debug:
+    msg: Current kubectl image version is {{ ks_kubectl_tag }}
+
 - name: ks-events | Getting ks-events installation files
   template:
     src: "{{ item.file }}.j2"

--- a/roles/ks-monitor/tasks/prometheus-rules.yaml
+++ b/roles/ks-monitor/tasks/prometheus-rules.yaml
@@ -8,10 +8,10 @@
   shell: >
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/prometheus/prometheus-rules.yaml
   when:
-    - kubernetes_version.stdout is version('v1.16.0', '<')
+    - kubernetes_version is version('v1.16.0', '<')
 
 - name: Monitoring | Creating Prometheus rules (v1.16.0+)
   shell: >
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/prometheus/prometheus-rules-v1.16+.yaml
   when:
-    - kubernetes_version.stdout is version('v1.16.0', '>=')
+    - kubernetes_version is version('v1.16.0', '>=')

--- a/roles/ks-multicluster/tasks/main.yml
+++ b/roles/ks-multicluster/tasks/main.yml
@@ -7,6 +7,21 @@
   loop:
     - "kubefed"
 
+- debug:
+    msg: Current Kubernetes version is {{ kubernetes_version }}
+
+# Get the matched kubectl image
+- name: KubeSphere | Setting kubectl image version
+  set_fact:
+    ks_kubectl_tag: "{{ item.value }}"
+    kubectl_break: true
+  loop: "{{ query('dict', ks_kubectl_versions) }}"
+  when:
+    - kubectl_break is undefined and kubernetes_version is defined and kubernetes_version is version(item.key, '>=')
+
+- debug:
+    msg: Current kubectl image version is {{ ks_kubectl_tag }}
+
 - name: Kubefed | Creating manifests
   template:
     src: "{{ item.file }}.j2"

--- a/roles/ks-multicluster/templates/custom-values-kubefed.yaml.j2
+++ b/roles/ks-multicluster/templates/custom-values-kubefed.yaml.j2
@@ -46,7 +46,7 @@ controllermanager:
   postInstallJob:
     repository: {{ post_install_job_repo }}
     image: {{ post_install_job_image }}
-    tag: {{ post_install_job_tag }}
+    tag: {{ ks_kubectl_tag }}
   webhook:
     repository: {{ kubefed_repo }}
     image: {{ kubefed_image }}

--- a/roles/preinstall/tasks/precheck.yaml
+++ b/roles/preinstall/tasks/precheck.yaml
@@ -1,16 +1,16 @@
 ---
-- name: KubeSphere | Checking Kubernetes version
-  shell: >
-    {{ bin_dir }}/kubectl version -o json | jq -r '.serverVersion.gitVersion'
-  register: kubernetes_version
-
-- name: KubeSphere | Initing Kubernetes version
-  set_fact: >
-     k8s_version: {{ kubernetes_version.stdout }}
+#- name: KubeSphere | Checking Kubernetes version
+#  shell: >
+#    {{ bin_dir }}/kubectl version -o json | jq -r '.serverVersion.gitVersion'
+#  register: kubernetes_version
+#
+#- name: KubeSphere | Initing Kubernetes version
+#  set_fact: >
+#     k8s_version: {{ kubernetes_version }}
 
 - name: KubeSphere | Stopping if Kubernetes version is nonsupport
   assert:
-    that: kubernetes_version.stdout is version('v1.15.0', '>=')
+    that: kubernetes_version is version('v1.19.0', '>=')
     msg: "The current Kubernetes version is not supported !"
 
 - name: KubeSphere | Checking StorageClass


### PR DESCRIPTION
### What does this PR do?
At present, all the following components need to use `kubectl` image, but the tag is not unique, which leads to complicated image management. This pr makes all components use consistent `kubectl` image.
* ks-core
* kubefed
* ks-events

Signed-off-by: pixiake <guofeng@yunify.com>