### PR TITLE
Refine PipelineRuns management and viewing roles

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -342,12 +342,14 @@ rules:
       - devops
       - 'pipelines'
       - 'pipelines/runs'
+      - 'pipelines/pipelineruns'
       - 'pipelines/branches'
       - 'pipelines/checkScriptCompile'
       - 'pipelines/consolelog'
       - 'pipelines/scan'
       - 'pipelines/sonarstatus'
       - 'pipelineruns'
+      - 'pipelineruns/nodedetails'
       - 'checkCron'
       - 'credentials'
       - 'credentials/usage'
@@ -620,12 +622,14 @@ rules:
       - devops
       - pipelines
       - pipelines/runs
+      - pipelines/pipelineruns
       - pipelines/branches
       - pipelines/checkScriptCompile
       - pipelines/consolelog
       - pipelines/scan
       - pipelines/sonarstatus
       - pipelineruns
+      - pipelineruns/nodedetails
       - checkCron
       - credentials
       - credentials/usage
@@ -753,12 +757,14 @@ rules:
       - devops
       - pipelines
       - pipelines/runs
+      - pipelines/pipelineruns
       - pipelines/branches
       - pipelines/checkScriptCompile
       - pipelines/consolelog
       - pipelines/scan
       - pipelines/sonarstatus
       - pipelineruns
+      - pipelineruns/nodedetails
       - checkCron
       - credentials
       - credentials/usage
@@ -1324,12 +1330,14 @@ rules:
     resources:
       - 'pipelines'
       - 'pipelines/runs'
+      - 'pipelines/pipelineruns'
       - 'pipelines/branches'
       - 'pipelines/checkScriptCompile'
       - 'pipelines/consolelog'
       - 'pipelines/scan'
       - 'pipelines/sonarstatus'
       - 'pipelineruns'
+      - 'pipelineruns/nodedetails'
       - 'checkCron'
       - 'credentials'
       - 'credentials/usage'
@@ -1381,12 +1389,14 @@ rules:
     resources:
       - 'pipelines'
       - 'pipelines/runs'
+      - 'pipelines/pipelineruns'
       - 'pipelines/branches'
       - 'pipelines/checkScriptCompile'
       - 'pipelines/consolelog'
       - 'pipelines/scan'
       - 'pipelines/sonarstatus'
       - 'pipelineruns'
+      - 'pipelineruns/nodedetails'
       - 'checkCron'
       - 'credentials'
       - 'credentials/usage'
@@ -3141,7 +3151,7 @@ role:
   kind: Role
   metadata:
     annotations:
-      iam.kubesphere.io/dependencies: '["role-template-view-pipelines", "role-template-view-pipelineruns", "role-template-view-credentials"]'
+      iam.kubesphere.io/dependencies: '["role-template-view-pipelines", "role-template-manage-pipelineruns", "role-template-view-credentials"]'
       iam.kubesphere.io/module: Pipelines Management
       kubesphere.io/alias-name: Pipelines Management
       iam.kubesphere.io/role-template-rules: '{"pipelines": "manage", "pipelineruns": "manage"}'
@@ -3175,7 +3185,7 @@ role:
   metadata:
     annotations:
       iam.kubesphere.io/dependencies: '["role-template-view-pipelines", "role-template-view-pipelineruns"]'
-      iam.kubesphere.io/module: PipelineRuns Management
+      iam.kubesphere.io/module: Pipelines Management
       kubesphere.io/alias-name: PipelineRuns Management
       iam.kubesphere.io/role-template-rules: '{"pipelineruns": "manage"}'
     labels:
@@ -3186,6 +3196,9 @@ role:
         - '*'
       resources:
         - 'pipelineruns'
+        - 'pipelines/runs'
+        - 'pipelines/pipelineruns'
+        - 'pipelineruns/nodedetails'
         - 'pipelineruns/status'
       verbs:
         - '*'
@@ -3231,6 +3244,7 @@ role:
   kind: Role
   metadata:
     annotations:
+      iam.kubesphere.io/dependencies: '["role-template-view-pipelineruns"]'
       iam.kubesphere.io/module: Pipelines Management
       kubesphere.io/alias-name: Pipelines View
       iam.kubesphere.io/role-template-rules: '{"pipelines": "view", "pipelineruns": "view"}'
@@ -3265,7 +3279,7 @@ role:
   kind: Role
   metadata:
     annotations:
-      iam.kubesphere.io/module: PipelineRuns Management
+      iam.kubesphere.io/module: Pipelines Management
       kubesphere.io/alias-name: PipelineRuns View
       iam.kubesphere.io/role-template-rules: '{"pipelineruns": "view"}'
     labels:
@@ -3276,6 +3290,9 @@ role:
         - '*'
       resources:
         - 'pipelineruns'
+        - 'pipelines/runs'
+        - 'pipelines/pipelineruns'
+        - 'pipelineruns/nodedetails'
         - 'pipelineruns/status'
       verbs:
         - 'get'


### PR DESCRIPTION
### What this PR dose

- Add `pipelines/runs`, `pipelines/pipelineruns` and `pipelineruns/nodedetails` resources into PipelineRun's RolBase.
- Adjust role dependencies for `view-pipelines` and `manage-pipelines` roles.
  - view-pipelines -> view-pipelineruns
  - manage-pipelines -> manage-pipelineruns, view-pipelines, view-credentials
![image](https://user-images.githubusercontent.com/16865714/145317655-37d6e7b7-b36d-44ee-907f-098a8bc19bc0.png)

### Why we need it

Firstly, we need a finer grained permissions for PipelineRuns. Then, if the missing resources were not added, users has `Pipeline Viewing` and `PipelineRun Viewing` roles could not view any PipelineRuns in console.

BTW, this PR is related with #1828.

### Steps to test

1. Apply the role templates into cluster
    ```bash
    kubectl apply -f https://raw.githubusercontent.com/kubesphere/ks-installer/aacef83af34391bda2ce43143c0cc0df2956d6ce/roles/ks-core/prepare/files/ks-init/role-templates.yaml
    ```
2. Create a Workspace, DevOps Project and simple Pipeline.
    ```groovy
    pipeline {
        agent none
        stages {
            stage('Example') {
                input {
                    message "Should we continue?"
                    ok "Yes, we should."
                    submitter "alice,bob"
                    parameters {
                        string(name: 'PERSON', defaultValue: 'Mr Jenkins', description: 'Who should I say hello to?')
                    }
                }
                steps {
                    echo "Hello, ${PERSON}, nice to meet you."
                }
            }
        }
    }
    ```
3. Run the Pipeline
3. Create a role for the DevOps Project created before, which has `view-pipelines` permissions
4. Create a user and assign the role created before to the user
5. Validate the result

/kind bug
/area devops
/cc @kubesphere/sig-devops 
/milestone v3.2