### PR TITLE
upgrade kube-state-metrics version

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -138,7 +138,7 @@ prometheus_operator_tag: v0.43.2
 kube_rbac_proxy_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/kube-rbac-proxy"
 kube_rbac_proxy_tag: v0.8.0
 kube_state_metrics_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/kube-state-metrics"
-kube_state_metrics_tag: v1.9.7
+kube_state_metrics_tag: v2.3.0
 node_exporter_repo: "{{ base_repo }}{{ namespace_override | default('prom') }}/node-exporter"
 node_exporter_tag: v0.18.1
 prometheus_adapter_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/k8s-prometheus-adapter-amd64"

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
@@ -21,10 +21,21 @@ rules:
   - persistentvolumes
   - namespaces
   - endpoints
+  - ingresses
   verbs:
   - list
   - watch
   - delete
+- apiGroups:
+    - extensions
+    - networking.k8s.io
+  resources:
+    - ingresses
+    - ingressclasses
+  verbs:
+    - get
+    - list
+    - watch
 - apiGroups:
   - extensions
   resources:

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -23,8 +23,8 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        - --metric-blacklist=kube_pod_container_status_.*terminated_reason,kube_.+_version,kube_.+_created,kube_deployment_(spec_paused|spec_strategy_rollingupdate_.+),kube_endpoint_(info|address_.+),kube_job_(info|owner|spec_(parallelism|active_deadline_seconds)|status_(active|.+_time)),kube_cronjob_(info|status_.+|spec_.+),kube_namespace_(status_phase),kube_persistentvolume_(info|capacity_.+),kube_persistentvolumeclaim_(resource_.+|access_.+),kube_secret_(type),kube_service_(spec_.+|status_.+),kube_ingress_(info|path|tls),kube_replicaset_(status_.+|spec_.+|owner),kube_poddisruptionbudget_status_.+,kube_replicationcontroller_.+,kube_node_info,kube_(hpa|replicaset|replicationcontroller)_.+_generation
-        image: kubesphere/kube-state-metrics:v1.9.7
+        - --metric-denylist=kube_pod_container_status_.*terminated_reason,kube_.+_version,kube_.+_created,kube_deployment_(spec_paused|spec_strategy_rollingupdate_.+),kube_endpoint_(info|address_.+),kube_job_(info|owner|spec_(parallelism|active_deadline_seconds)|status_(active|.+_time)),kube_cronjob_(info|status_.+|spec_.+),kube_namespace_(status_phase),kube_persistentvolume_(info|capacity_.+),kube_persistentvolumeclaim_(resource_.+|access_.+),kube_secret_(type),kube_service_(spec_.+|status_.+),kube_ingress_(info|path|tls),kube_replicaset_(status_.+|spec_.+|owner),kube_poddisruptionbudget_status_.+,kube_replicationcontroller_.+,kube_node_info,kube_(hpa|replicaset|replicationcontroller)_.+_generation
+        image: kubesphere/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         securityContext:
           runAsUser: 65534


### PR DESCRIPTION
fix this issue
https://kubesphere.com.cn/forum/d/6344-kube-state-metricsv1bate1

use `kube-state-metrics:v2.3.0`   image
![image](https://user-images.githubusercontent.com/17962021/146528368-a230ca03-7005-4722-9fc2-2cacb0d0804f.png)

watch ingresses resources
![image](https://user-images.githubusercontent.com/17962021/146528504-aade9496-49d7-4bc8-9047-a3d456a0d1d2.png)



kubesphere repo must have `kube-state-metrics:v2.3.0`  


change the parameter `--metric-blacklist` to `--metric-denylist`

https://github.com/kubernetes/kube-state-metrics/blob/master/docs/cli-arguments.md



