### PR TITLE
Add read permission jenkins/labelsData to pipeline view role

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -3262,6 +3262,7 @@ role:
         - 'pipelines/consolelog'
         - 'pipelines/scan'
         - 'pipelines/sonarstatus'
+        - 'jenkins/labelsData'
       verbs:
         - 'get'
         - 'list'


### PR DESCRIPTION
We are using the API `devops.kubesphere.io/v1alpha2/devops/testsscxjkq/jenkins/labelsdashboard/labelsData` to get all the labels from Jenkins.

To those users who want to define a customized role, they will meet the following errors:

```json
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {
    
  },
  "status": "Failure",
  "message": "jenkins.devops.kubesphere.io \"labelsdashboard\" is forbidden: User \"rick\" cannot get resource \"jenkins/labelsData\" in API group \"devops.kubesphere.io\" at the cluster scope",
  "reason": "Forbidden",
  "details": {
    "name": "labelsdashboard",
    "group": "devops.kubesphere.io",
    "kind": "jenkins"
  },
  "code": 403
}
```

## Scope
This bug affects v3.0.0 to v3.2.1

## How to fix in the previous version
Please consider adding `jenkins/labelsData` to your roles:

```shell
/ # kubectl edit role -n testsscxjkq good
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
....
rules:
- apiGroups:
  - '*'
  resources:
  - pipelines/scan
  - pipelines/sonarstatus
  - jenkins/labelsData
```

/area devops