### PR TITLE
fix: add permission 'jenkins/labelsData' to pipline manage role

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -3169,6 +3169,7 @@ role:
         - 'pipelines/consolelog'
         - 'pipelines/scan'
         - 'pipelines/sonarstatus'
+        - 'jenkins/labelsData'
       verbs:
         - '*'
 


### PR DESCRIPTION
Fix: https://github.com/kubesphere/ks-devops/issues/430