### PR TITLE
fix: add resource' request and limit to the jaeger-cr.

### DIFF
--- a/roles/ks-istio/templates/jaeger-cr.yaml.j2
+++ b/roles/ks-istio/templates/jaeger-cr.yaml.j2
@@ -11,6 +11,13 @@ spec:
   collector:
     image: {{ jaeger_collector_repo }}:{{ jaeger_collector_tag }}
     maxReplicas: 5
+    resources:
+      limits:
+        cpu: {{ servicemesh.jaeger.resources.limits.cpu | default("100m") }}
+        memory: {{ servicemesh.jaeger.resources.limits.memory | default("128Mi") }}
+      requests:
+        cpu: {{ servicemesh.jaeger.resources.requests.cpu | default("20m") }}
+        memory: {{ servicemesh.jaeger.resources.requests.memory | default("50Mi") }}
   query:
     image: {{ jaeger_query_repo }}:{{ jaeger_query_tag }}
   storage:


### PR DESCRIPTION
Description: jaeger-collector hpa alerting error: failed to get memory utilization: missing request for memory. The resource of jaeger-collector does not define.

Fix: https://github.com/kubesphere/kubesphere/issues/4565