### PR TITLE
Optimisation of container runtime selection for logging plugins

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -95,7 +95,6 @@ spec:
     #   resources: {}
   logging:                 # (CPU: 57 m, Memory: 2.76 G) Flexible logging functions are provided for log query, collection and management in a unified console. Additional log collectors can be added, such as Elasticsearch, Kafka and Fluentd.
     enabled: false         # Enable or disable the KubeSphere Logging System.
-    containerruntime: docker
     logsidecar:
       enabled: true
       replicas: 2

--- a/roles/common/tasks/fluentbit-install.yaml
+++ b/roles/common/tasks/fluentbit-install.yaml
@@ -3,6 +3,28 @@
     src: "fluentbit-operator"
     dest: "{{ kubesphere_dir }}/"
 
+- name: ks-logging | Getting Kubernetes Node info
+  shell: |
+    kubectl get node -ojson | jq '.items[0].status.nodeInfo.containerRuntimeVersion'
+  register: node_container_runtime
+
+
+- name: ks-logging | Setting container runtime of kubernetes
+  set_fact:
+    logging_container_runtime: "{{ node_container_runtime.stdout is search('docker://') | ternary('docker', 'containerd') }}"
+
+- name: ks-logging | Setting container runtime of kubernetes
+  set_fact:
+    logging_container_runtime: "{{ node_container_runtime.stdout is search('containerd://') | ternary('containerd', 'crio') }}"
+  when: logging_container_runtime == 'containerd'
+
+- name: ks-logging | Debug container_runtime
+  debug:
+    msg: "{{node_container_runtime}}"
+
+- name: ks-logging | Debug logging_container_runtime
+  debug:
+    msg: "{{logging_container_runtime}}"
 
 - name: KubeSphere | Creating custom manifests
   template:

--- a/roles/common/templates/custom-fluentbit-operator-deployment.yaml.j2
+++ b/roles/common/templates/custom-fluentbit-operator-deployment.yaml.j2
@@ -21,18 +21,7 @@ spec:
       - name: env
         emptyDir: {}
 {% if common.containersLogMountedPath is defined and common.containersLogMountedPath != "" %}
-{% elif (logging.containerruntime is defined) and (logging.containerruntime == 'containerd') %}
-      - name: containerdsock
-        hostPath:
-          path: /var/run/containerd/containerd.sock
-      - name: crictl
-        hostPath:
-          path: {{ logging.crictlPath | default('/usr/bin/crictl') }}
-{% elif (logging.containerruntime is defined) and (logging.containerruntime == 'crio') %}
-      - name: crisock
-        hostPath:
-          path: /var/run/crio/crio.sock
-{% else %}
+{% elif logging_container_runtime == 'docker' %}
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock
@@ -46,9 +35,7 @@ spec:
         - set -ex;
 {% if common.containersLogMountedPath is defined and common.containersLogMountedPath != "" %}
           echo CONTAINER_ROOT_DIR={{ common.containersLogMountedPath }} > /fluentbit-operator/fluent-bit.env
-{% elif (logging.containerruntime is defined) and (logging.containerruntime == 'containerd') %}
-          echo CONTAINER_ROOT_DIR=$(crictl info --output go-template --template {{'{{.config.containerdRootDir}}'}}) > /fluentbit-operator/fluent-bit.env
-{% elif (logging.containerruntime is defined) and (logging.containerruntime == 'crio') %}
+{% elif (logging_container_runtime== 'containerd') or (logging_container_runtime== 'crio') %}
           echo CONTAINER_ROOT_DIR=/var/log > /fluentbit-operator/fluent-bit.env
 {% else %}
           echo CONTAINER_ROOT_DIR=$(docker info -f {{'{{.DockerRootDir}}'}}) > /fluentbit-operator/fluent-bit.env
@@ -57,18 +44,7 @@ spec:
         - name: env
           mountPath: /fluentbit-operator
 {% if common.containersLogMountedPath is defined and common.containersLogMountedPath != "" %}
-{% elif (logging.containerruntime is defined) and (logging.containerruntime == 'containerd') %}
-        - name: containerdsock
-          readOnly: true
-          mountPath: /var/run/containerd/containerd.sock
-        - name: crictl
-          readOnly: true
-          mountPath: {{ logging.crictlPath | default('/usr/bin/crictl') }}
-{% elif (logging.containerruntime is defined) and (logging.containerruntime == 'crio') %}
-        - name: crisock
-          readOnly: true
-          mountPath: /var/run/crio/crio.sock
-{% else %}
+{% elif logging_container_runtime == 'docker' %}
         - name: dockersock
           readOnly: true
           mountPath: /var/run/docker.sock

--- a/roles/ks-auditing/tasks/fluentbit-operator.yaml
+++ b/roles/ks-auditing/tasks/fluentbit-operator.yaml
@@ -3,6 +3,27 @@
     path: "{{ kubesphere_dir }}/fluentbit-operator"
     state: directory
 
+
+- name: ks-auditing | Getting Kubernetes Node info
+  shell: |
+    kubectl get node -ojson | jq '.items[0].status.nodeInfo.containerRuntimeVersion'
+  register: node_container_runtime
+
+
+- name: ks-auditing | Setting container runtime of kubernetes
+  set_fact:
+    logging_container_runtime: "{{ node_container_runtime.stdout is search('docker://') | ternary('docker', 'containerd') }}"
+
+- name: ks-auditing | Setting container runtime of kubernetes
+  set_fact:
+    logging_container_runtime: "{{ node_container_runtime.stdout is search('containerd://') | ternary('containerd', 'crio') }}"
+  when: logging_container_runtime == 'containerd'
+
+- name: ks-auditing | Debug logging_container_runtime
+  debug:
+    msg: "{{logging_container_runtime}}"
+
+
 - name: ks-auditing | Creating manifests
   template:
     src: "{{ item.file }}.j2"

--- a/roles/ks-auditing/tasks/main.yaml
+++ b/roles/ks-auditing/tasks/main.yaml
@@ -5,6 +5,7 @@
     src: "kube-auditing"
     dest: "{{ kubesphere_dir }}/ks-auditing/"
 
+
 - name: ks-auditing | getting ks-auditing installation files
   template:
     src: "{{ item.file }}.j2"

--- a/roles/ks-auditing/templates/custom-filter-auditing.yaml.j2
+++ b/roles/ks-auditing/templates/custom-filter-auditing.yaml.j2
@@ -9,7 +9,7 @@ metadata:
 spec:
   filters:
     - parser:
-{% if (logging.containerruntime is defined) and (logging.containerruntime == 'containerd' or logging.containerruntime == 'crio' ) %}
+{% if (logging_container_runtime== 'containerd') or (logging_container_runtime== 'crio') %}
         keyName: message
 {% else %}
         keyName: log

--- a/roles/ks-auditing/templates/custom-input-auditing.yaml.j2
+++ b/roles/ks-auditing/templates/custom-input-auditing.yaml.j2
@@ -11,7 +11,7 @@ spec:
     db: /fluent-bit/tail/pos-auditing.db
     dbSync: Normal
     memBufLimit: 5MB
-{% if (logging.containerruntime is defined) and (logging.containerruntime == 'containerd' or logging.containerruntime == 'crio' ) %}
+{% if (logging_container_runtime== 'containerd') or (logging_container_runtime== 'crio') %}
     parser: cri
 {% else %}
     parser: docker

--- a/roles/ks-events/tasks/fluentbit-operator.yaml
+++ b/roles/ks-events/tasks/fluentbit-operator.yaml
@@ -3,6 +3,26 @@
     path: "{{ kubesphere_dir }}/fluentbit-operator"
     state: directory
 
+
+- name: ks-events | Getting Kubernetes Node info
+  shell: |
+    kubectl get node -ojson | jq '.items[0].status.nodeInfo.containerRuntimeVersion'
+  register: node_container_runtime
+
+
+- name: ks-events | Setting container runtime of kubernetes
+  set_fact:
+    logging_container_runtime: "{{ node_container_runtime.stdout is search('docker://') | ternary('docker', 'containerd') }}"
+
+- name: ks-events | Setting container runtime of kubernetes
+  set_fact:
+    logging_container_runtime: "{{ node_container_runtime.stdout is search('containerd://') | ternary('containerd', 'crio') }}"
+  when: logging_container_runtime == 'containerd'
+
+- name: ks-events | Debug logging_container_runtime
+  debug:
+    msg: "{{logging_container_runtime}}"
+
 - name: ks-events | Creating manifests
   template:
     src: "{{ item.file }}.j2"

--- a/roles/ks-events/tasks/main.yaml
+++ b/roles/ks-events/tasks/main.yaml
@@ -8,6 +8,7 @@
 - debug:
     msg: Current Kubernetes version is {{ kubernetes_version }}
 
+
 # Get the matched kubectl image
 - name: KubeSphere | Setting kubectl image version
   set_fact:

--- a/roles/ks-events/templates/custom-filter-events.yaml.j2
+++ b/roles/ks-events/templates/custom-filter-events.yaml.j2
@@ -10,7 +10,7 @@ spec:
   match: kube_events
   filters:
     - parser:
-{% if (logging.containerruntime is defined) and (logging.containerruntime == 'containerd' or logging.containerruntime == 'crio' ) %}
+{% if (logging_container_runtime== 'containerd') or (logging_container_runtime== 'crio') %}
         keyName: message
 {% else %}
         keyName: log

--- a/roles/ks-events/templates/custom-input-events.yaml.j2
+++ b/roles/ks-events/templates/custom-input-events.yaml.j2
@@ -10,7 +10,7 @@ spec:
   tail:
     tag: kube_events
     path: /var/log/containers/*_kubesphere-logging-system_events-exporter*.log
-{% if (logging.containerruntime is defined) and (logging.containerruntime == 'containerd' or logging.containerruntime == 'crio' ) %}
+{% if (logging_container_runtime== 'containerd') or (logging_container_runtime== 'crio') %}
     parser: cri
 {% else %}
     parser: docker

--- a/roles/ks-logging/tasks/main.yaml
+++ b/roles/ks-logging/tasks/main.yaml
@@ -10,6 +10,21 @@
     src: "fluentbit-operator-cri"
     dest: "{{ kubesphere_dir }}/"
 
+- name: ks-logging | Getting Kubernetes Node info
+  shell: |
+    kubectl get node -ojson | jq '.items[0].status.nodeInfo.containerRuntimeVersion'
+  register: node_container_runtime
+
+
+- name: ks-logging | Setting container runtime of kubernetes
+  set_fact:
+    logging_container_runtime: "{{ node_container_runtime.stdout is search('docker://') | ternary('docker', 'containerd') }}"
+
+- name: ks-logging | Setting container runtime of kubernetes
+  set_fact:
+    logging_container_runtime: "{{ node_container_runtime.stdout is search('containerd://') | ternary('containerd', 'crio') }}"
+  when: logging_container_runtime == 'containerd'
+
 
 - name: ks-logging | Checking fluent-bit migrating
   shell: >
@@ -47,12 +62,13 @@
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/fluentbit-operator
 
 
+
 - name: ks-logging | Apply fluent-bit operator cri custom resources
   shell: >
     {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/fluentbit-operator-cri
   when:
-    - logging is defined and logging.enabled and logging.containerruntime is defined
-    - logging.containerruntime == 'containerd' or logging.containerruntime == 'crio'
+    - logging is defined and logging.enabled
+    - logging_container_runtime == 'containerd' or logging_container_runtime == 'crio'
 
 
 - import_tasks: logsidecar.yaml

--- a/roles/ks-logging/templates/custom-input-logging.yaml.j2
+++ b/roles/ks-logging/templates/custom-input-logging.yaml.j2
@@ -10,9 +10,9 @@ spec:
   tail:
     tag: kube.*
     path: /var/log/containers/*.log
-{% if (logging.containerruntime is defined) and (logging.containerruntime == 'containerd' or logging.containerruntime == 'crio' ) %}
+{% if (logging_container_runtime== 'containerd') or (logging_container_runtime== 'crio') %}
     parser: cri
-{% else  %}
+{% else %}
     parser: docker
 {% endif %}
     refreshIntervalSeconds: 10

--- a/roles/ks-logging/templates/custom-input-systemd.yaml.j2
+++ b/roles/ks-logging/templates/custom-input-systemd.yaml.j2
@@ -1,16 +1,16 @@
 apiVersion: logging.kubesphere.io/v1alpha2
 kind: Input
 metadata:
-  name: {{ logging.containerruntime | default('docker') }}
+  name: {{ logging_container_runtime | default('docker') }}
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
     logging.kubesphere.io/component: logging
 spec:
   systemd:
-    tag: service.{{ logging.containerruntime | default('docker') }}
+    tag: service.{{ logging_container_runtime | default('docker') }}
     path: /var/log/journal
     db: /fluent-bit/tail/docker.db
     dbSync: Normal
     systemdFilter:
-      - _SYSTEMD_UNIT={{ logging.containerruntime | default('docker') }}.service
+      - _SYSTEMD_UNIT={{ logging_container_runtime | default('docker') }}.service


### PR DESCRIPTION
In previous versions, we needed to set the `logging.containerruntime`  field. This may have been a solution. But it would face upgrades or other problems. This would undoubtedly increase the burden of use on the user. In this pr, `ks-installer` can automatically detect the user's container runtime without the user having to enter it manually.   




Signed-off-by: chengdehao <dehaocheng@kubesphere.io>