### PR TITLE
Enable clustertemplates resources list and get for authenticated global role

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -222,6 +222,13 @@ rules:
       - list
       - get
   - apiGroups:
+      - devops.kubesphere.io
+    resources:
+      - clustertemplates
+    verbs:
+      - list
+      - get
+  - apiGroups:
       - alerting.kubesphere.io
     resources:
       - comment


### PR DESCRIPTION
### What this PR does

Add clustertemplates resources list and get rules for authenticated global role.

### Which issue this PR fixes

Fixes https://github.com/kubesphere/ks-devops/issues/470

### Steps to test

0. Apply ClusterTemplate CRD
    ```bash
    kubectl apply -f https://raw.githubusercontent.com/kubesphere-sigs/ks-devops-helm-chart/master/charts/ks-devops/crds/devops.kubesphere.io_clustertemplates.yaml
    kubectl apply -f https://raw.githubusercontent.com/kubesphere-sigs/ks-devops-helm-chart/master/charts/ks-devops/templates/cluster-template-ci.yaml
    ```
2. Apply role-template.yaml
    ```bash
    kubectl apply -f https://raw.githubusercontent.com/kubesphere/ks-installer/4d0f1ad372e54faad9cb89f9aaa97dd4d28092ac/roles/ks-core/prepare/files/ks-init/role-templates.yaml
    ```
3. Create a normal user and login with that user
4. Request cluster templates like below
    ```bash
    http://your_ip:30880/kapis/devops.kubesphere.io/v1alpha3/clustertemplates
    ```

/kind feature
/area devops

/cc @kubesphere/sig-installation 
/cc @kubesphere/sig-devops 