### PR TITLE
disable processes collector for node exporter

### DIFF
--- a/roles/ks-monitor/files/prometheus/node-exporter/node-exporter-daemonset.yaml
+++ b/roles/ks-monitor/files/prometheus/node-exporter/node-exporter-daemonset.yaml
@@ -41,7 +41,6 @@ spec:
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
-        - --collector.processes
         image: prom/node-exporter:v1.3.1
         name: node-exporter
         resources:

--- a/roles/ks-monitor/files/prometheus/node-exporter/node-exporter-serviceMonitor.yaml
+++ b/roles/ks-monitor/files/prometheus/node-exporter/node-exporter-serviceMonitor.yaml
@@ -15,7 +15,7 @@ spec:
     interval: 1m
     metricRelabelings:
     - action: keep
-      regex: node_(uname|network)_info|node_cpu_.+|node_memory_Mem.+_bytes|node_memory_SReclaimable_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes|node_network_(.+_bytes_total|up)|node_network_.+_errs_total|node_nf_conntrack_entries.*|node_disk_.+_completed_total|node_disk_.+_bytes_total|node_filesystem_files|node_filesystem_files_free|node_filesystem_avail_bytes|node_filesystem_size_bytes|node_filesystem_free_bytes|node_filesystem_readonly|node_load.+|node_timex_offset_seconds|node_processes_.+
+      regex: node_(uname|network)_info|node_cpu_.+|node_memory_Mem.+_bytes|node_memory_SReclaimable_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes|node_network_(.+_bytes_total|up)|node_network_.+_errs_total|node_nf_conntrack_entries.*|node_disk_.+_completed_total|node_disk_.+_bytes_total|node_filesystem_files|node_filesystem_files_free|node_filesystem_avail_bytes|node_filesystem_size_bytes|node_filesystem_free_bytes|node_filesystem_readonly|node_load.+|node_timex_offset_seconds
       sourceLabels:
       - __name__
     port: https

--- a/roles/ks-monitor/templates/node-exporter-daemonset.yaml.j2
+++ b/roles/ks-monitor/templates/node-exporter-daemonset.yaml.j2
@@ -39,7 +39,6 @@ spec:
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
-        - --collector.processes
         image: {{ node_exporter_repo }}:{{ node_exporter_tag }}
         name: node-exporter
         resources:


### PR DESCRIPTION
Remove arg `--collector.processes`  for node exporter to disable node processes/threads metrics collection. 

It just synchronizes update in https://github.com/kubesphere/ks-prometheus/pull/2 to here.