### PR TITLE
Set the role of the current cluster into the kubesphere-config configmap

### DIFF
--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -111,8 +111,12 @@ data:
         secretAccessKey: {{ common.s3.secretAccessKey | default('openpitrixminiosecretkey') }}
         bucket: {{ common.s3.openpitrixBucket | default('app-store') }}
 {% endif %}
-{% if multicluster.clusterRole is defined and multicluster.clusterRole == "host" %}
     multicluster:
+      clusterRole: {{ multicluster.clusterRole }}
+{% if multicluster.clusterRole is defined and multicluster.clusterRole == "member" %}
+      enable: false
+{% endif %}
+{% if multicluster.clusterRole is defined and multicluster.clusterRole == "host" %}
       enable: true
       agentImage: {{ tower_repo }}/{{ tower_image }}:{{ tower_image_tag }}
       proxyPublishService: tower.kubesphere-system.svc


### PR DESCRIPTION
Part of https://github.com/kubesphere/kubesphere/issues/4610

/cc @wansir 