### PR TITLE
Support to build multi-architecture images

### DIFF
--- a/.github/workflows/e2e-TEST.yml
+++ b/.github/workflows/e2e-TEST.yml
@@ -2,10 +2,13 @@ name: e2e-TEST
 
 on:
   push:
-    branches: [master, release-3.1]
+    branches:
+      - 'master'
+      - 'release-*'
   pull_request:
-    branches: [master, release-3.1]
-
+    branches:
+      - 'master'
+      - 'release-*'
 env:
   # TODO: Change variable to your image's name.
   IMAGE_NAME: ks-installer
@@ -21,6 +24,8 @@ jobs:
       is_MY_SECRET_set: ${{ steps.checksecret_job.outputs.is_MY_SECRET_set }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Clean up
       run: kind delete cluster --name chart-testing && docker image prune -f
@@ -106,19 +111,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get Version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/heads/}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Log into registry
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Get Version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/heads/}
+
       - name: Push image
         run: |
           IMAGE=$IMAGE_REPO/$IMAGE_NAME:${{ steps.get_version.outputs.VERSION }}
-          docker build . --file Dockerfile --tag $IMAGE
-          echo $IMAGE
-          docker push $IMAGE
+          docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile.complete -t $IMAGE .
           echo "Push $IMAGE success!"
       - name: slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -20,23 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build image
-        run: |
-          tag=nightly-$(date '+%Y%m%d')
-          sed -i "2idev_tag\: $tag" roles/download/defaults/main.yml
-          docker build . --file Dockerfile --tag $IMAGE_NAME
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Log into registry
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Push image
+      - name: Build image
         run: |
-          IMAGE_ID=$IMAGE_REPO/$IMAGE_NAME
-          
           tag=nightly-$(date '+%Y%m%d')
-
-          docker tag $IMAGE_NAME $IMAGE_ID:${tag}
-          docker push $IMAGE_ID:${tag}
+          sed -i "2idev_tag\: $tag" roles/download/defaults/main.yml
+          docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile.complete -t $IMAGE_REPO/$IMAGE_NAME:$tag .
 
       - name: slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 name: Build Release
 
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: ks-installer
+  IMAGE_REPO: kubesphere
+
 jobs:
   release-linux-amd64:
     runs-on: ubuntu-latest
@@ -65,3 +70,19 @@ jobs:
           asset_name: images-list.txt
           asset_content_type: application/txt
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log into registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE=$IMAGE_REPO/$IMAGE_NAME:${{ steps.get_version.outputs.VERSION }}
+          docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile.complete -t $IMAGE .
+          echo "Push $IMAGE success!"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kubespheredev/shell-operator:v1.0.0-beta.5-alpine3.15
+FROM kubespheredev/shell-operator:v1.0.0-beta.5-alpine
 
 ENV  ANSIBLE_ROLES_PATH /kubesphere/installer/roles
 WORKDIR /kubesphere

--- a/Dockerfile.complete
+++ b/Dockerfile.complete
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.15
+FROM golang:1.16-alpine
 
 ARG appVersion=latest
 
@@ -12,19 +12,22 @@ WORKDIR /go/src/github.com/flant/shell-operator
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$appVersion'" -o shell-operator ./cmd/shell-operator
 
 
-FROM python:3.10-alpine3.15
+FROM python:3.10-alpine
+
+ENV ARCH=amd64
 
 RUN apk --no-cache add jq yq bash curl unzip openssl && \
     apk --no-cache add gcc libffi-dev openssl-dev musl-dev && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
-    pip install --no-cache-dir ansible_runner==2.0.1 ansible==2.9.23 kubernetes && \ 
+    pip install --no-cache-dir ansible_runner==2.1.2 ansible==2.9.27 kubernetes && \
     apk del gcc libffi-dev openssl-dev musl-dev && \
-    wget https://get.helm.sh/helm-v3.6.3-linux-amd64.tar.gz && \
-    tar -zxf helm-v3.6.3-linux-amd64.tar.gz && \
-    mv linux-amd64/helm /bin/helm && \
-    rm -rf *linux-amd64* && \
+    if [[ $(arch) == "aarch64*" ]]; then ARCH=arm64; fi && \
+    wget https://get.helm.sh/helm-v3.6.3-linux-${ARCH}.tar.gz && \
+    tar -zxf helm-v3.6.3-linux-${ARCH}.tar.gz && \
+    mv linux-${ARCH}/helm /bin/helm && \
+    rm -rf *linux-${ARCH}* && \
     chmod +x /bin/helm && \
-    wget https://storage.googleapis.com/kubernetes-release/release/v1.18.18/bin/linux/amd64/kubectl -O /bin/kubectl && \
+    wget https://storage.googleapis.com/kubernetes-release/release/v1.21.10/bin/linux/${ARCH}/kubectl -O /bin/kubectl && \
     chmod +x /bin/kubectl && \
     ln -s /bin/kubectl /usr/local/bin/kubectl && \
     ln -s /bin/helm /usr/local/bin/helm && \

--- a/Dockerfile.shelloperator
+++ b/Dockerfile.shelloperator
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.15
+FROM golang:1.16-alpine
 
 ARG appVersion=latest
 
@@ -12,19 +12,22 @@ WORKDIR /go/src/github.com/flant/shell-operator
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$appVersion'" -o shell-operator ./cmd/shell-operator
 
 
-FROM python:3.10-alpine3.15
+FROM python:3.10-alpine
+
+ENV ARCH=amd64
 
 RUN apk --no-cache add jq yq bash curl unzip openssl && \
     apk --no-cache add gcc libffi-dev openssl-dev musl-dev && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
-    pip install --no-cache-dir ansible_runner==2.0.1 ansible==2.9.23 kubernetes && \ 
+    pip install --no-cache-dir ansible_runner==2.1.2 ansible==2.9.27 kubernetes && \
     apk del gcc libffi-dev openssl-dev musl-dev && \
-    wget https://get.helm.sh/helm-v3.6.3-linux-amd64.tar.gz && \
-    tar -zxf helm-v3.6.3-linux-amd64.tar.gz && \
-    mv linux-amd64/helm /bin/helm && \
-    rm -rf *linux-amd64* && \
+    if [[ $(arch) == "aarch64*" ]]; then ARCH=arm64; fi && \
+    wget https://get.helm.sh/helm-v3.6.3-linux-${ARCH}.tar.gz && \
+    tar -zxf helm-v3.6.3-linux-${ARCH}.tar.gz && \
+    mv linux-${ARCH}/helm /bin/helm && \
+    rm -rf *linux-${ARCH}* && \
     chmod +x /bin/helm && \
-    wget https://storage.googleapis.com/kubernetes-release/release/v1.18.18/bin/linux/amd64/kubectl -O /bin/kubectl && \
+    wget https://storage.googleapis.com/kubernetes-release/release/v1.21.10/bin/linux/${ARCH}/kubectl -O /bin/kubectl && \
     chmod +x /bin/kubectl && \
     ln -s /bin/kubectl /usr/local/bin/kubectl && \
     ln -s /bin/helm /usr/local/bin/helm && \

--- a/roles/common/tasks/es-install.yaml
+++ b/roles/common/tasks/es-install.yaml
@@ -37,7 +37,7 @@
   shell: >
     {{ bin_dir }}/kubectl create secret generic elasticsearch-credentials --from-literal="username={{ common.es.basicAuth.username }}" --from-literal="password={{ common.es.basicAuth.password }}" --type=kubernetes.io/basic-auth -n kubesphere-logging-system
   register: secret
-  failed_when: "secret.stderr and 'AlreadyExists' not in secret.stderr"
+  failed_when: "secret.stderr and 'already exists' not in secret.stderr"
   until: secret is succeeded
   retries: 5
   delay: 10

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -141,7 +141,7 @@
 #    --from-file={{ kubesphere_dir }}/common/password.txt
 #    -n kubesphere-system
 #  register: import
-#  failed_when: "import.stderr and 'AlreadyExists' not in import.stderr"
+#  failed_when: "import.stderr and 'already exists' not in import.stderr"
 
 - name: KubeSphere | Deploying common component
   block:

--- a/roles/common/tasks/redis-install.yaml
+++ b/roles/common/tasks/redis-install.yaml
@@ -7,7 +7,7 @@
       shell: >
         {{ bin_dir }}/kubectl -n kubesphere-system create secret generic redis-secret --from-literal=auth={{redis_password}}
       register: secret
-      failed_when: "secret.stderr and 'AlreadyExists' not in secret.stderr"
+      failed_when: "secret.stderr and 'already exists' not in secret.stderr"
 
 - name: KubeSphere | Deploying ha redis
   block:

--- a/roles/ks-core/config/tasks/main.yaml
+++ b/roles/ks-core/config/tasks/main.yaml
@@ -105,6 +105,6 @@
   loop:
     - "kubesphere-config.yaml"
   register: init_result
-  failed_when: "init_result.stderr and 'AlreadyExists' not in init_result.stderr"
+  failed_when: "init_result.stderr and 'already exists' not in init_result.stderr"
 
 - import_tasks: ks-restart.yaml

--- a/roles/ks-core/init-token/tasks/main.yaml
+++ b/roles/ks-core/init-token/tasks/main.yaml
@@ -67,4 +67,4 @@
     --from-literal=secret={{ ks_secret_str }}
     -n kubesphere-system
   register: secret_status
-  failed_when: "secret_status.stderr and 'AlreadyExists' not in secret_status.stderr"
+  failed_when: "secret_status.stderr and 'already exists' not in secret_status.stderr"

--- a/roles/ks-core/ks-core/tasks/main.yaml
+++ b/roles/ks-core/ks-core/tasks/main.yaml
@@ -122,7 +122,7 @@
     -f {{ kubesphere_dir }}/ks-core/custom-values-ks-core.yaml
     --namespace kubesphere-system
   # register: source_state
-  # failed_when: "source_state.stderr and 'AlreadyExists' not in source_state.stderr"
+  # failed_when: "source_state.stderr and 'already exists' not in source_state.stderr"
 
 - name: KubeSphere | Importing ks-core status
   shell: >

--- a/roles/ks-core/prepare/tasks/main.yaml
+++ b/roles/ks-core/prepare/tasks/main.yaml
@@ -71,7 +71,7 @@
   loop:
     - "role-templates.yaml"
   register: init_ks_result
-  failed_when: "init_ks_result.stderr and 'AlreadyExists' not in init_ks_result.stderr and 'Warning' not in init_ks_result.stderr"
+  failed_when: "init_ks_result.stderr and 'already exists' not in init_ks_result.stderr and 'Warning' not in init_ks_result.stderr"
 
 
 - name: KubeSphere | Generating kubeconfig-admin

--- a/roles/ks-istio/tasks/main.yaml
+++ b/roles/ks-istio/tasks/main.yaml
@@ -11,7 +11,9 @@
 
 - name: servicemesh | Unarchive istio files
   shell: >
-    tar -zxf {{ kubesphere_dir }}/servicemesh/istio/istio-1.11.2-linux-amd64.tar.gz -C {{ kubesphere_dir }}/servicemesh/istio/
+    ARCH=amd64 &&
+    if [[ $(arch) == "aarch64*" ]]; then ARCH=arm64; fi &&
+    tar -zxf {{ kubesphere_dir }}/servicemesh/istio/istio-1.11.2-linux-${ARCH}.tar.gz -C {{ kubesphere_dir }}/servicemesh/istio/
 
 - name: servicemesh | Grant privileges to ks-installer
   shell: >


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

### What this PR does / why we need it:
Support to build multi-architecture images for ks-installer.
1. Add the detection and judgment of the environment architecture in the Dockerfile.
2. Adjust the pipeline of github action to support automatic multi-architecture images building for ks-installer.
3. Adjust the string for judging that the resource already exists. （`AlreadyExists` -> `already exists`）