### PR TITLE
Support custom node-export's port

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -103,6 +103,9 @@ spec:
     enabled: false                   # Enable or disable metrics-server.
   monitoring:
     storageClass: ""                 # If there is an independent StorageClass you need for Prometheus, you can specify it here. The default StorageClass is used by default.
+    node_exporter:
+      port: 9100
+      # resources: {}
     # kube_rbac_proxy:
     #   resources: {}
     # kube_state_metrics:
@@ -113,8 +116,6 @@ spec:
     #   resources: {}
     #   operator:
     #     resources: {}
-    # node_exporter:
-    #   resources: {}
     # alertmanager:
     #   replicas: 1          # AlertManager Replicas.
     #   resources: {}

--- a/roles/ks-monitor/templates/node-exporter-daemonset.yaml.j2
+++ b/roles/ks-monitor/templates/node-exporter-daemonset.yaml.j2
@@ -31,7 +31,7 @@ spec:
                 operator: DoesNotExist
       containers:
       - args:
-        - --web.listen-address=127.0.0.1:9100
+        - --web.listen-address=127.0.0.1:{{ monitoring.node_exporter.port | default("9100") }}
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
@@ -61,9 +61,9 @@ spec:
           readOnly: true
       - args:
         - --logtostderr
-        - --secure-listen-address=[$(IP)]:9100
+        - --secure-listen-address=[$(IP)]:{{ monitoring.node_exporter.port | default("9100") }}
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-        - --upstream=http://127.0.0.1:9100/
+        - --upstream=http://127.0.0.1:{{ monitoring.node_exporter.port | default("9100") }}/
         env:
         - name: IP
           valueFrom:
@@ -72,8 +72,8 @@ spec:
         image: {{ kube_rbac_proxy_repo }}:{{ kube_rbac_proxy_tag }}
         name: kube-rbac-proxy
         ports:
-        - containerPort: 9100
-          hostPort: 9100
+        - containerPort: {{ monitoring.node_exporter.port | default("9100") }}
+          hostPort: {{ monitoring.node_exporter.port | default("9100") }}
           name: https
         securityContext:
           runAsGroup: 65532


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

### What this PR does / why we need it:
In some clusters, there is conflict between node-export's port (default `9100`) and the other services.
So we should support customizing node-expor's port to improve flexibility.

### How to use:
Add `spec.monitoring.node-exporter.port: xxx` to the configuration file.

```
spec:
  ...
  monitoring:
    node_exporter:
      port: 9100
  ...
```