### PR TITLE
fixed the ks-install label in logs command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3
 Then inspect the logs of installation.
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-install -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 When all Pods of KubeSphere are running, it means the installation is successful. Check the port (30880 by default) of the console service by the following command. Then you can use `http://IP:30880` to access the console with the default account `admin/P@88w0rd`.


### PR DESCRIPTION
`kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-install -o jsonpath='{.items[0].metadata.name}') -f`

The label is fixed as app=ks-install 