### PR TITLE
Install CRDs before installing or upgrading DevOps using Helm

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -122,7 +122,7 @@ builder_go16_podman_tag: v3.2.0-podman
 
 #s2i
 s2i_registry: "{{ base_repo }}{{ namespace_override | default('kubespheredev') }}"
-s2ioperator_tag: "v3.2.0"
+s2ioperator_tag: "v3.2.1"
 s2irun_tag: "v3.2.0"
 s2itemplates_tag: "v3.2.0"
 

--- a/roles/ks-devops/tasks/main.yaml
+++ b/roles/ks-devops/tasks/main.yaml
@@ -165,8 +165,8 @@
 
 - name: ks-devops | Stop the existing Jenkins
   shell: |
-    {{ bin_dir }}/kubectl -n kubesphere-devops-system delete service ks-jenkins-agent
-    {{ bin_dir }}/kubectl -n kubesphere-devops-system delete service ks-jenkins
+    {{ bin_dir }}/kubectl -n kubesphere-devops-system delete service ks-jenkins-agent --ignore-not-found
+    {{ bin_dir }}/kubectl -n kubesphere-devops-system delete service ks-jenkins --ignore-not-found
     {{ bin_dir }}/kubectl -n kubesphere-devops-system scale deployment ks-jenkins --replicas=0
   ignore_errors: True
   when:
@@ -191,8 +191,17 @@
   shell: |
     # Delete Job migrate because 'helm upgrade' will try to update immutable fields of Job, which is not allowed. 
     {{ bin_dir }}/kubectl delete job -n kubesphere-devops-system migrate --ignore-not-found
+    
+    ks_devops_chart_version=0.1.10
+    charts_folder={{ kubesphere_dir }}/ks-devops/charts
+    ks_devops_chart=$charts_folder/ks-devops-$ks_devops_chart_version.tgz
+    
+    # Create or update CRDs manually
+    tar xzvf $ks_devops_chart -C $charts_folder
+    {{ bin_dir }}/kubectl apply -f $charts_folder/ks-devops/crds
+    {{ bin_dir }}/kubectl apply -f $charts_folder/ks-devops/charts/s2i/crds
 
-    {{ bin_dir }}/helm upgrade --install devops {{ kubesphere_dir }}/ks-devops/charts/ks-devops-0.1.10.tgz \
+    {{ bin_dir }}/helm upgrade --install devops $ks_devops_chart \
     -n kubesphere-devops-system \
     -f {{ kubesphere_dir }}/ks-devops/ks-devops-values.yaml
   register: devops_upgrade_result

--- a/roles/ks-devops/templates/ks-devops-values.yaml.j2
+++ b/roles/ks-devops/templates/ks-devops-values.yaml.j2
@@ -59,6 +59,9 @@ affinity: {}
 s2i:
   image:
     registry: "{{ s2i_registry }}"
+  s2ioperator:
+    image:
+      tag: "{{ s2ioperator_tag }}"
   prometheus:
     namespace: "kubesphere-monitoring-system"
 


### PR DESCRIPTION
### What this PR does

- Extract Helm chart package and install CRDs manually before installing or upgrading DevOps using Helm.
- Bump s2ioperator tag to v3.2.1

### How to test?

1. install KubeSphere v3.2.1 and enable DevOps. You can refer to document: https://kubesphere.io/docs/pluggable-components/devops/
2. Scale replicas of ks-installer to 0 and upadate image of ks-installer container

    ```bash
    kubectl scale --replicas=0 deployment/ks-installer -nkubesphere-system
    kubectl patch -nkubesphere-system deployment ks-installer --type=json -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "johnniang/ks-installer:refactor-install-crds-manually-dev"}]'
    ```
3. Remove DevOps status in ClusterConfiguration
    ```bash
    kubectl patch -nkubesphere-system cc ks-installer --type=json -p='[{"op": "remove", "path": "/status/devops"}]'
    ```

4. Enjoy upgrade of DevOps

    ```bash
    kubectl scale --replicas=1 deployment/ks-installer -nkubesphere-system
    kubectl logs -n kubesphere-system deploy/ks-installer --tail 200 -f
    ```

/area devops
/kind enhancement

/cc @kubesphere/sig-devops 