### PR TITLE
Resolve member cluster can not log in from console

### DIFF
--- a/roles/ks-core/ks-core/files/ks-core/templates/kubesphere-config.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/kubesphere-config.yaml
@@ -21,6 +21,11 @@ data:
 {{- else if eq (default .Values.config.multicluster.clusterRole "none") "member" }}
       oauthOptions:
         accessTokenMaxAge: 0
+        clients:
+          - name: kubesphere
+            secret: kubesphere
+            redirectURIs:
+              - '*'
 {{- end }}
     monitoring:
       endpoint: {{ .Values.config.monitoring.endpoint | default "http://prometheus-operated.kubesphere-monitoring-system.svc:9090" }}


### PR DESCRIPTION
When cluster is a member cluster ks-installer will missing some configuration in kubesphere.yaml that cause user can not login from member cluster
see https://github.com/kubesphere/kubesphere/issues/4771