### PR TITLE
Refine installation logic

### DIFF
--- a/deploy/cluster-configuration.yaml
+++ b/deploy/cluster-configuration.yaml
@@ -180,5 +180,5 @@ spec:
     # audit:
     #   resources: {}
   terminal:
-    image: 'alpine:3.15' # There must be an nsenter program in the image
+    # image: 'alpine:3.15' # There must be an nsenter program in the image
     timeout: 600         # Container timeout, if set to 0, no timeout will be used. The unit is seconds

--- a/roles/ks-core/config/templates/kubesphere-config.yaml.j2
+++ b/roles/ks-core/config/templates/kubesphere-config.yaml.j2
@@ -214,9 +214,7 @@ data:
 
 {% if terminal is defined %}
     terminal:
-{% if terminal.image is defined %}
-      image: {{ terminal.image }}
-{% endif %}
+      image: {{ terminal.image | default(alpine_repo + ':' + alpine_tag|string) }}
 {% if terminal.timeout is defined %}
       timeout: {{ terminal.timeout }}
 {% endif %}

--- a/roles/ks-monitor/tasks/prometheus-operator.yaml
+++ b/roles/ks-monitor/tasks/prometheus-operator.yaml
@@ -1,7 +1,18 @@
 ---
-- name: Monitoring | Initing prometheus-operator
+- name: Monitoring | Initing prometheus-operator (crds)
   # Client-side apply may fail because of large crds, so do server-side apply as a complement
   # Refer to https://github.com/prometheus-operator/prometheus-operator/pull/4349 and https://github.com/kubernetes/kubernetes/issues/82292 
+  shell: "{{ bin_dir }}/kubectl apply -f {{ item }} --force || {{ bin_dir }}/kubectl apply -f {{ item }} --force-conflicts --server-side"
+  loop: '{{ query("fileglob", "{{ kubesphere_dir }}/prometheus/prometheus-operator/*CustomResourceDefinition.yaml") }}'
+  register: prom_result
+  failed_when: "prom_result.stderr and 'Warning' not in prom_result.stderr and 'spec.clusterIP' not in prom_result.stderr"
+  until: prom_result is succeeded
+  retries: 5
+  delay: 3
+
+- name: Monitoring | Initing prometheus-operator (resources)
+  # Client-side apply may fail because of large crds, so do server-side apply as a complement
+  # Refer to https://github.com/prometheus-operator/prometheus-operator/pull/4349 and https://github.com/kubernetes/kubernetes/issues/82292
   shell: "{{ bin_dir }}/kubectl apply -f {{ item }} --force || {{ bin_dir }}/kubectl apply -f {{ item }} --force-conflicts --server-side"
   loop: '{{ query("fileglob", "{{ kubesphere_dir }}/prometheus/prometheus-operator/*.yaml") }}'
   register: prom_result


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

### What this PR does / why we need it:
Refine installation logic.
* Apply prometheus' custom resources first to prevent the failure of resources installation because the resource definition cannot be found.
* Use ks-installer to manage terminal image.