### PR TITLE
Update clusters.cluster.kubesphere.io CRD to latest version

### DIFF
--- a/roles/ks-core/ks-core/files/ks-core/crds/cluster.kubesphere.io_clusters.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/crds/cluster.kubesphere.io_clusters.yaml
@@ -35,10 +35,14 @@ spec:
         description: Cluster is the schema for the clusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -47,31 +51,57 @@ spec:
               connection:
                 description: Connection holds info to connect to the member cluster
                 properties:
+                  externalKubernetesAPIEndpoint:
+                    description: External Kubernetes API Server endpoint Will be populated
+                      by ks-apiserver if connection type is proxy and ExternalKubeAPIEnabled
+                      is true.
+                    type: string
                   kubeconfig:
-                    description: KubeConfig content used to connect to cluster api server Should provide this field explicitly if connection type is direct. Will be populated by ks-proxy if connection type is proxy.
+                    description: KubeConfig content used to connect to cluster api
+                      server Should provide this field explicitly if connection type
+                      is direct. Will be populated by ks-proxy if connection type
+                      is proxy.
                     format: byte
                     type: string
                   kubernetesAPIEndpoint:
-                    description: 'Kubernetes API Server endpoint. Example: https://10.10.0.1:6443 Should provide this field explicitly if connection type is direct. Will be populated by ks-apiserver if connection type is proxy.'
+                    description: 'Kubernetes API Server endpoint. Example: https://10.10.0.1:6443
+                      Should provide this field explicitly if connection type is direct.
+                      Will be populated by ks-apiserver if connection type is proxy.'
                     type: string
                   kubernetesAPIServerPort:
-                    description: KubeAPIServerPort is the port which listens for forwarding kube-apiserver traffic Only applicable when connection type is proxy.
+                    description: KubeAPIServerPort is the port which listens for forwarding
+                      kube-apiserver traffic Only applicable when connection type
+                      is proxy.
                     type: integer
                   kubesphereAPIEndpoint:
-                    description: 'KubeSphere API Server endpoint. Example: http://10.10.0.11:8080 Should provide this field explicitly if connection type is direct. Will be populated by ks-apiserver if connection type is proxy.'
+                    description: 'KubeSphere API Server endpoint. Example: http://10.10.0.11:8080
+                      Should provide this field explicitly if connection type is direct.
+                      Will be populated by ks-apiserver if connection type is proxy.'
                     type: string
                   kubesphereAPIServerPort:
-                    description: KubeSphereAPIServerPort is the port which listens for forwarding kubesphere apigateway traffic Only applicable when connection type is proxy.
+                    description: KubeSphereAPIServerPort is the port which listens
+                      for forwarding kubesphere apigateway traffic Only applicable
+                      when connection type is proxy.
                     type: integer
                   token:
-                    description: Token used by agents of member cluster to connect to host cluster proxy. This field is populated by apiserver only if connection type is proxy.
+                    description: Token used by agents of member cluster to connect
+                      to host cluster proxy. This field is populated by apiserver
+                      only if connection type is proxy.
                     type: string
                   type:
-                    description: type defines how host cluster will connect to host cluster ConnectionTypeDirect means direct connection, this requires   kubeconfig and kubesphere apiserver endpoint provided ConnectionTypeProxy means using kubesphere proxy, no kubeconfig   or kubesphere apiserver endpoint required
+                    description: type defines how host cluster will connect to host
+                      cluster ConnectionTypeDirect means direct connection, this requires   kubeconfig
+                      and kubesphere apiserver endpoint provided ConnectionTypeProxy
+                      means using kubesphere proxy, no kubeconfig   or kubesphere
+                      apiserver endpoint required
                     type: string
                 type: object
               enable:
                 description: Desired state of the cluster
+                type: boolean
+              externalKubeAPIEnabled:
+                description: ExternalKubeAPIEnabled export kubeapiserver to public
+                  use a lb type service if connection type is proxy
                 type: boolean
               joinFederation:
                 description: Join cluster as a kubefed cluster
@@ -83,11 +113,13 @@ spec:
           status:
             properties:
               conditions:
-                description: Represents the latest available observations of a cluster's current state.
+                description: Represents the latest available observations of a cluster's
+                  current state.
                 items:
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
@@ -95,7 +127,8 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -114,22 +147,33 @@ spec:
               configz:
                 additionalProperties:
                   type: boolean
-                description: Configz is status of components enabled in the member cluster. This is synchronized with member cluster every amount of time, like 5 minutes.
+                description: Configz is status of components enabled in the member
+                  cluster. This is synchronized with member cluster every amount of
+                  time, like 5 minutes.
                 type: object
               kubeSphereVersion:
-                description: GitVersion of the /kapis/version api response, this field is populated by cluster controller
+                description: GitVersion of the /kapis/version api response, this field
+                  is populated by cluster controller
                 type: string
               kubernetesVersion:
-                description: GitVersion of the kubernetes cluster, this field is populated by cluster controller
+                description: GitVersion of the kubernetes cluster, this field is populated
+                  by cluster controller
                 type: string
               nodeCount:
-                description: Count of the kubernetes cluster nodes This field may not reflect the instant status of the cluster.
+                description: Count of the kubernetes cluster nodes This field may
+                  not reflect the instant status of the cluster.
                 type: integer
               region:
-                description: Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'.
+                description: Region is the name of the region in which all of the
+                  nodes in the cluster exist.  e.g. 'us-east1'.
+                type: string
+              uid:
+                description: UID is the kube-system namespace UID of the cluster,
+                  which represents the unique ID of the cluster.
                 type: string
               zones:
-                description: Zones are the names of availability zones in which the nodes of the cluster exist, e.g. 'us-east1-a'.
+                description: Zones are the names of availability zones in which the
+                  nodes of the cluster exist, e.g. 'us-east1-a'.
                 items:
                   type: string
                 type: array


### PR DESCRIPTION
We have added a new field `uid` for cluster CRD in version 3.3: https://github.com/kubesphere/kubesphere/commit/7deb9c274650fa5f63ae71d75559e88bc8a40b33, https://github.com/kubesphere/kubesphere/pull/4651

This patch sync the latest cluster CRD to the ks-installer

fix https://github.com/kubesphere/kubesphere/issues/4790
fix https://github.com/kubesphere/kubesphere/issues/4792

/cc @pixiake 