### PR TITLE
revert prometheus service monitor selector

### DIFF
--- a/roles/ks-monitor/files/prometheus/prometheus/prometheus-prometheus.yaml
+++ b/roles/ks-monitor/files/prometheus/prometheus/prometheus-prometheus.yaml
@@ -74,7 +74,5 @@ spec:
     runAsUser: 1000
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
-  serviceMonitorSelector:
-    matchLabels:
-      app.kubernetes.io/vendor: kubesphere
+  serviceMonitorSelector: {}
   version: 2.34.0

--- a/roles/ks-monitor/templates/prometheus-prometheus.yaml.j2
+++ b/roles/ks-monitor/templates/prometheus-prometheus.yaml.j2
@@ -110,9 +110,7 @@ spec:
     runAsUser: 0
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
-  serviceMonitorSelector:
-    matchLabels:
-      app.kubernetes.io/vendor: kubesphere
+  serviceMonitorSelector: {}
   storage:
     volumeClaimTemplate:
       spec:


### PR DESCRIPTION
It just synchronizes update in https://github.com/kubesphere/ks-prometheus/pull/5 to here.

/cc @benjaminhuo 