### PR TITLE
fix "namespace_override" for library

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -16,7 +16,7 @@ base_library_repo: >-
   {% if (local_registry is defined and local_registry == "registry.cn-beijing.aliyuncs.com") or (zone is defined and zone == "cn") -%}
   {{ base_repo }}{{ namespace_override | default('kubesphereio') }}/
   {%- elif local_registry is defined and local_registry != "" -%}
-  {{ base_repo }}library/
+  {{ base_repo }}{{ namespace_override | default('library') }}/
   {%- else -%}
 
   {%- endif %}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix the problem that `namespace_override` doesn't work for images using `library`.


Signed-off-by: pixiake <guofeng@yunify.com>