### PR TITLE
keep the old label 'app: ks-install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ kubeedge:
 3. Inspect the logs of installation.
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-install -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 ## Upgrade

--- a/README_zh.md
+++ b/README_zh.md
@@ -49,7 +49,7 @@ kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3
 kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3.2.1/cluster-configuration.yaml
 
  # 查看部署进度及日志
- $ kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+ $ kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-install -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 部署完成后可执行如下命令查看控制台的服务端口，使用 `IP:consolePort(default: 30880)` 访问 KubeSphere UI 界面，默认的集群管理员账号为 `admin/P@88w0rd`。
@@ -95,7 +95,7 @@ kubectl edit cc ks-installer -n kubesphere-system
 > 按功能需求编辑配置文件之后，退出等待生效即可，如长时间未生效请使用如下命令查看相关日志:
 
 ```bash
-kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath='{.items[0].metadata.name}') -f
+kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=ks-install -o jsonpath='{.items[0].metadata.name}') -f
 ```
 
 > 如果你正在启用 KubeEdge ，在运行或重启 ks-installer 之前，需要配置集群外网访问地址advertiseAddress，暴露相应的访问端口，更多内容请参考[Kubeedge 指南](https://kubesphere.io/docs/pluggable-components/kubeedge/)：

--- a/deploy/kubesphere-installer.yaml
+++ b/deploy/kubesphere-installer.yaml
@@ -273,16 +273,16 @@ metadata:
   name: ks-installer
   namespace: kubesphere-system
   labels:
-    app: ks-installer
+    app: ks-install
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ks-installer
+      app: ks-install
   template:
     metadata:
       labels:
-        app: ks-installer
+        app: ks-install
     spec:
       serviceAccountName: ks-installer
       containers:

--- a/docs/IstioUpgradeGuide.md
+++ b/docs/IstioUpgradeGuide.md
@@ -20,7 +20,7 @@ curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.4.8 sh - && cd istio-1.
 2. Get custom setting files from ks-installer
 
 ```bash
-pod=$(kubectl get pod -n kubesphere-system -l app=ks-installer -o jsonpath={.items[0].metadata.name})
+pod=$(kubectl get pod -n kubesphere-system -l app=ks-install -o jsonpath={.items[0].metadata.name})
 kubectl -n kubesphere-system exec $pod cat /etc/kubesphere/istio/custom-values-istio-init.yaml > custom-values-istio-init.yaml
 kubectl -n kubesphere-system exec $pod cat /etc/kubesphere/istio/custom-values-istio.yaml > custom-values-istio.yaml
 kubectl -n kubesphere-system exec $pod  sed -i 's/1.3.3/1.4.8/g' /kubesphere/installer/roles/download/defaults

--- a/scripts/check_cluster_status.sh
+++ b/scripts/check_cluster_status.sh
@@ -7,7 +7,7 @@ set -o pipefail
 function check_installer_ok(){
     echo "waiting for ks-installer pod ready"
     kubectl -n kubesphere-system wait --timeout=180s --for=condition=Available deployment/ks-installer
-    kubectl -n kubesphere-system wait --timeout=180s --for=condition=Ready $(kubectl -n kubesphere-system get pod -l app=ks-installer -oname)
+    kubectl -n kubesphere-system wait --timeout=180s --for=condition=Ready $(kubectl -n kubesphere-system get pod -l app=ks-install -oname)
     echo "waiting for KubeSphere ready"
     while IFS= read -r line; do
         echo "$line"


### PR DESCRIPTION
## What this PR does / why we need it:
The change of label causes the e2e test to fail and the document is invalid. So keep the label `app: ks-install`.

Signed-off-by: pixiake <guofeng@yunify.com>