### PR TITLE
[release-3.3] fix Dockerfile wildcard character error

### DIFF
--- a/Dockerfile.complete
+++ b/Dockerfile.complete
@@ -21,7 +21,7 @@ RUN apk --no-cache add jq yq bash curl unzip openssl && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install --no-cache-dir ansible_runner==2.1.2 ansible==2.9.27 kubernetes && \
     apk del gcc libffi-dev openssl-dev musl-dev && \
-    if [[ $(arch) == "aarch64*" ]]; then ARCH=arm64; fi && \
+    if [[ $(arch) == aarch64* ]]; then ARCH=arm64; fi && \
     wget https://get.helm.sh/helm-v3.6.3-linux-${ARCH}.tar.gz && \
     tar -zxf helm-v3.6.3-linux-${ARCH}.tar.gz && \
     mv linux-${ARCH}/helm /bin/helm && \

--- a/Dockerfile.shelloperator
+++ b/Dockerfile.shelloperator
@@ -21,7 +21,7 @@ RUN apk --no-cache add jq yq bash curl unzip openssl && \
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
     pip install --no-cache-dir ansible_runner==2.1.2 ansible==2.9.27 kubernetes && \
     apk del gcc libffi-dev openssl-dev musl-dev && \
-    if [[ $(arch) == "aarch64*" ]]; then ARCH=arm64; fi && \
+    if [[ $(arch) == aarch64* ]]; then ARCH=arm64; fi && \
     wget https://get.helm.sh/helm-v3.6.3-linux-${ARCH}.tar.gz && \
     tar -zxf helm-v3.6.3-linux-${ARCH}.tar.gz && \
     mv linux-${ARCH}/helm /bin/helm && \


### PR DESCRIPTION
test environment：
OS: Debian GNU/Linux 10 (buster) aarch64
Host: KVM Virtual Machine virt-4.2
Kernel: 4.19.0-20-arm64

if [[ $(arch) == "aarch64*" ]]; then ARCH=arm64; fi -> failed
if [[ $(arch) == "aarch64"* ]]; then ARCH=arm64; fi -> success
if [[ $(arch) == aarch64* ]]; then ARCH=arm64; fi -> success

I tried testing inside a Docker container and on the host machine, "aarch64*" -> failed.

This results in the inability to download the correct package in the arm64 environment.