### PR TITLE
Support to use an alternative image build tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 REPO?=kubespheredev/ks-installer
-TAG:=$(shell git rev-parse --abbrev-ref HEAD | sed -e 's/\//-/g')-dev
+TAG:=$(shell git rev-parse --abbrev-ref HEAD | sed -e 's/\//-/g')-dev-$(shell git rev-parse --short HEAD)
+CONTAINER_CLI?=docker
 
 build:
-	docker build . --file Dockerfile --tag $(REPO):$(TAG)
+	$(CONTAINER_CLI) build . --file Dockerfile --tag $(REPO):$(TAG)
 push:
-	docker push $(REPO):$(TAG)
+	$(CONTAINER_CLI) push $(REPO):$(TAG)
 all: build push


### PR DESCRIPTION
See my test output:
```shell
rick@DESKTOP-KSDCPBK:~/ws/github/kubesphere/ks-installer$ podman images | head
REPOSITORY                                TAG                   IMAGE ID      CREATED       SIZE
docker.io/library/alpine                  latest                0ac33e5f5afa  5 weeks ago   5.86 MB
rick@DESKTOP-KSDCPBK:~/ws/github/kubesphere/ks-installer$ echo $CONTAINER_CLI
podman
rick@DESKTOP-KSDCPBK:~/ws/github/kubesphere/ks-installer$ make build
podman build . --file Dockerfile --tag kubespheredev/ks-installer:master-dev-833dfa3e
STEP 1/8: FROM kubespheredev/shell-operator:v1.0.0-beta.5-alpine
STEP 2/8: ENV  ANSIBLE_ROLES_PATH /kubesphere/installer/roles
--> Using cache 0fd53e651e354bb5abc8b3acb444728340e2f41d6cb9dfd19cb3858345252439
--> 0fd53e651e3
STEP 3/8: WORKDIR /kubesphere
--> Using cache c3c9668b8a4af18ec352341d5c9beaad75baff1392ab4b3168b75f42da708bb7
```
