### PR TITLE
Clean kubefed resources before uninstall

### DIFF
--- a/scripts/kubesphere-delete.sh
+++ b/scripts/kubesphere-delete.sh
@@ -32,8 +32,26 @@ done
 # delete kubefed
 kubectl get cc -n kubesphere-system ks-installer -o jsonpath="{.status.multicluster}" | grep enable
 if [[ $? -eq 0 ]]; then
+  # delete kubefed types resources
+  for kubefed in `kubectl api-resources --namespaced=true --api-group=types.kubefed.io -o name`
+  do
+    kubectl delete -n kube-federation-system $kubefed --all 2>/dev/null
+  done
+  for kubefed in `kubectl api-resources --namespaced=false --api-group=types.kubefed.io -o name`
+  do
+    kubectl delete $kubefed --all 2>/dev/null
+  done
+  # delete kubefed core resouces
+  for kubefed in `kubectl api-resources --namespaced=true --api-group=core.kubefed.io -o name`
+  do
+    kubectl delete -n kube-federation-system $kubefed --all 2>/dev/null
+  done
+  for kubefed in `kubectl api-resources --namespaced=false --api-group=core.kubefed.io -o name`
+  do
+    kubectl delete $kubefed --all 2>/dev/null
+  done
+  # uninstall kubefed chart
   helm uninstall -n kube-federation-system kubefed 2>/dev/null
-  #kubectl delete ns kube-federation-system 2>/dev/null
 fi
 
 
@@ -181,7 +199,7 @@ done
 # delete crds
 for crd in `kubectl get crds -o jsonpath="{.items[*].metadata.name}"`
 do
-  if [[ $crd == *kubesphere.io ]]; then kubectl delete crd $crd 2>/dev/null; fi
+  if [[ $crd == *kubesphere.io ]] || [[ $crd == *kubefed.io ]] ; then kubectl delete crd $crd 2>/dev/null; fi
 done
 
 # delete relevance ns


### PR DESCRIPTION
#### Issue
The kubesphere-delete.sh won't propely remove kubefed from the cluster before removing kubesphere , resulting in namespace kube-federation-system hanging in Terminating state.

#### Cause
Neither the kubefed CRDs or resources are removed prior to deleting the namespace.

#### Solution  
Clean-up kubefed resources before uninstalling the helm chart as well *.kubefed.io crds before completely removing kube-federation-system namespace.   

**Note**:  Following the uninstallation method of the kubefed chart described here https://github.com/kubesphere/ks-installer/tree/master/roles/ks-multicluster/files/kubefed/kubefed#uninstalling-the-chart didn't work 