### PR TITLE
Add gitops.kubesphere.io group to the global management role

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -577,6 +577,7 @@ rules:
       - alerting.kubesphere.io
       - cluster.kubesphere.io
       - types.kubefed.io
+      - gitops.kubesphere.io
     resources:
       - '*'
     verbs:
@@ -704,6 +705,7 @@ rules:
       - workloads
       - groups
       - groupbindings
+      - applications/sync
     verbs:
       - get
       - list

--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -453,6 +453,7 @@ rules:
       - alerting.kubesphere.io
       - network.kubesphere.io
       - resources.kubesphere.io
+      - gitops.kubesphere.io
     resources:
       - '*'
     verbs:


### PR DESCRIPTION
fix https://github.com/kubesphere/ks-devops/issues/595
