### PR TITLE
create service account token

### DIFF
--- a/roles/ks-core/ks-core/files/ks-core/templates/_helpers.tpl
+++ b/roles/ks-core/ks-core/files/ks-core/templates/_helpers.tpl
@@ -63,6 +63,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the secret of sa token.
+*/}}
+{{- define "ks-core.serviceAccountTokenName" -}}
+{{-  printf "%s-%s" ( include "ks-core.serviceAccountName" . )   "sa-token" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Returns user's password or use default
 */}}
 {{- define "getOrDefaultPass" }}

--- a/roles/ks-core/ks-core/files/ks-core/templates/serviceaccount.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/serviceaccount.yaml
@@ -1,4 +1,24 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create  -}}
+{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ks-core.serviceAccountTokenName" . }}
+  labels:
+    {{- include "ks-core.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    kubernetes.io/service-account.name: {{ include "ks-core.serviceAccountName" . }}
+    {{- end }}
+  {{- else }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "ks-core.serviceAccountName" . }}
+  {{- end }}
+type: kubernetes.io/service-account-token
+{{- end }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,6 +29,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.GitVersion }}
+secrets:
+  - name: {{ include "ks-core.serviceAccountTokenName" . }}
+{{- end }}
 {{- end }}
 
 ---


### PR DESCRIPTION
After kubernetes v1.24, kube-conteoller-manager will not create the default token for service account.
Create default token for as `kubesphere`.

/cc @wansir 
/cc @pixiake 