### PR TITLE
Support to read the repository path of argocd from the center file

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -160,7 +160,7 @@ argocd_applicationset_repo: "{{ quay_image_repo }}{{ namespace_override | defaul
 argocd_applicationset_tag: v0.4.1
 argocd_dex_repo: "{{ ghcr_image_repo }}{{ namespace_override | default('dexidp') }}/dex"
 argocd_dex_tag: v2.30.2
-argocd_redis_repo: "{{ base_repo }}{{ namespace_override }}/redis"
+argocd_redis_repo: "{{ base_library_repo }}redis"
 argocd_redis_tag: 6.2.6-alpine
 
 #ks-monitor:

--- a/roles/ks-devops/tasks/main.yaml
+++ b/roles/ks-devops/tasks/main.yaml
@@ -109,6 +109,7 @@
     dest: "{{ kubesphere_dir }}/{{ item.path }}/{{ item.file }}"
   with_items:
     - { path: ks-devops, file: ks-devops-values.yaml }
+    - { path: ks-devops, file: argo-cd-values.yaml }
 
 - name: ks-devops | Checking if ks-devops has installed
   shell: |
@@ -177,7 +178,9 @@
     executable: /bin/bash
   shell: |
     {{ bin_dir }}/helm upgrade --install devops {{ kubesphere_dir }}/ks-devops/charts/argo-cd-4.4.0.tgz \
-    -n argocd --create-namespace --reuse-values
+    -n argocd --create-namespace --reuse-values \
+    -f {{ kubesphere_dir }}/ks-devops/argo-cd-values.yaml
+
   register: argocd_upgrade_result
   until: argocd_upgrade_result is succeeded
   when:

--- a/roles/ks-devops/templates/argo-cd-values.yaml.j2
+++ b/roles/ks-devops/templates/argo-cd-values.yaml.j2
@@ -1,0 +1,15 @@
+global:
+  image:
+    repository: "{{ argocd_repo }}"
+
+dex:
+  image:
+    repository: "{{ argocd_dex_repo }}"
+
+applicationSet:
+  image:
+    repository: "{{ argocd_applicationset_repo }}"
+
+redis:
+  image:
+    repository: "{{ argocd_redis_repo }}"


### PR DESCRIPTION
See also the usage of the argocd helm chart.

https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml
