### PR TITLE
refine upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Deploy the new version of ks-installer:
 ```bash
 # Notice: ks-installer will automatically migrate the configuration. Do not modify the cluster configuration by yourself.
 
-kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3.3.0/kubesphere-installer.yaml
+kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3.3.0/kubesphere-installer.yaml --force
 ```
 
 > Note: If your KubeSphere version is v3.1.0 or eariler, please upgrade to v3.2.x first.

--- a/README_zh.md
+++ b/README_zh.md
@@ -113,7 +113,7 @@ kubectl logs -n kubesphere-system $(kubectl get pod -n kubesphere-system -l app=
 ```bash
 # 注意: ks-installer会自动迁移cluster-configuration. 请勿自行修改.
 
-kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3.3.0/kubesphere-installer.yaml
+kubectl apply -f https://github.com/kubesphere/ks-installer/releases/download/v3.3.0/kubesphere-installer.yaml --force
 ```
 
 


### PR DESCRIPTION
## What this PR does / why we need it:
Because the label of delployment of ks-installer in  v3.3.0 has changed, the `--force`  needs to be added when upgrading.


Signed-off-by: pixiake <guofeng@yunify.com>