### PR TITLE
Add permission of ci/nodelabels

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -252,6 +252,12 @@ rules:
     verbs:
       - list
   - apiGroups:
+      - devops.kubesphere.io
+    resources:
+      - ci
+    verbs:
+      - get
+  - apiGroups:
       - resources.kubesphere.io
     resources:
       - namespaces


### PR DESCRIPTION
This is part of https://github.com/kubesphere/ks-devops/issues/738
