### PR TITLE
fix prometheus nodeSelector indent

### DIFF
--- a/roles/ks-monitor/templates/prometheus-prometheus.yaml.j2
+++ b/roles/ks-monitor/templates/prometheus-prometheus.yaml.j2
@@ -55,10 +55,10 @@ spec:
       app.kubernetes.io/version: {{ prometheus_tag | replace("v", "") }}
 {% if monitoring.nodeSelector is defined and monitoring.nodeSelector is not none %}
   nodeSelector:
-    {{ monitoring.nodeSelector | to_nice_yaml(indent=2) | indent(8) }}
+    {{ monitoring.nodeSelector | to_nice_yaml(indent=2) | indent(4) }}
 {% elif nodeSelector is defined and nodeSelector is not none %}
   nodeSelector:
-    {{ nodeSelector | to_nice_yaml(indent=2) | indent(8) }}
+    {{ nodeSelector | to_nice_yaml(indent=2) | indent(4) }}
 {% else %}
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
fix wrong indents in nodeSelector of prometheus template file. (https://github.com/kubesphere/ks-installer/pull/2046 just fixes the tolerations)