### PR TITLE
upgrade kube-state-metrics version

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -175,7 +175,7 @@ prometheus_operator_tag: v0.55.1
 kube_rbac_proxy_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/kube-rbac-proxy"
 kube_rbac_proxy_tag: v0.11.0
 kube_state_metrics_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/kube-state-metrics"
-kube_state_metrics_tag: v2.3.0
+kube_state_metrics_tag: v2.5.0
 node_exporter_repo: "{{ base_repo }}{{ namespace_override | default('prom') }}/node-exporter"
 node_exporter_tag: v1.3.1
 alertmanager_repo: "{{ base_repo }}{{ namespace_override | default('prom') }}/alertmanager"

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.3.0
+    app.kubernetes.io/version: 2.5.0
   name: kubesphere-kube-state-metrics
 rules:
 - apiGroups:

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.3.0
+    app.kubernetes.io/version: 2.5.0
   name: kubesphere-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.3.0
+    app.kubernetes.io/version: 2.5.0
   name: kube-state-metrics
   namespace: kubesphere-monitoring-system
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 2.3.0
+        app.kubernetes.io/version: 2.5.0
     spec:
       containers:
       - args:
@@ -52,7 +52,7 @@ spec:
           kube_node_info,
           kube_(hpa|replicaset|replicationcontroller)_.+_generation
         - --metric-labels-allowlist=namespaces=[kubesphere.io/workspace]
-        image: kubesphere/kube-state-metrics:v2.3.0
+        image: kubesphere/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         resources:
           limits:

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.3.0
+    app.kubernetes.io/version: 2.5.0
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.3.0
+    app.kubernetes.io/version: 2.5.0
   name: kube-state-metrics
   namespace: kubesphere-monitoring-system
 spec:

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.3.0
+    app.kubernetes.io/version: 2.5.0
   name: kube-state-metrics
   namespace: kubesphere-monitoring-system

--- a/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
+++ b/roles/ks-monitor/files/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/vendor: kubesphere
-    app.kubernetes.io/version: 2.3.0
+    app.kubernetes.io/version: 2.5.0
   name: kube-state-metrics
   namespace: kubesphere-monitoring-system
 spec:


### PR DESCRIPTION
This synchronizes update in https://github.com/kubesphere/ks-prometheus/pull/9 to upgrade kube-state-metrics to v2.5.0.