### PR TITLE
Delete the role-templates annotation for disabling role to users

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -1662,7 +1662,6 @@ kind: WorkspaceRole
 metadata:
   annotations:
     iam.kubesphere.io/dependencies: '["role-template-view-members","role-template-view-roles"]'
-    iam.kubesphere.io/module: Access Control
     iam.kubesphere.io/role-template-rules: '{"members": "manage"}'
     kubesphere.io/alias-name: Workspace Members Management
   labels:
@@ -2723,7 +2722,6 @@ role:
   metadata:
     annotations:
       iam.kubesphere.io/dependencies: '["role-template-view-members","role-template-view-roles"]'
-      iam.kubesphere.io/module: Access Control
       iam.kubesphere.io/role-template-rules: '{"members": "manage"}'
       kubesphere.io/alias-name: Project Members Management
     labels:

--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -969,7 +969,6 @@ kind: GlobalRole
 metadata:
   annotations:
     iam.kubesphere.io/dependencies: '["role-template-view-users","role-template-view-roles"]'
-    iam.kubesphere.io/module: Access Control
     iam.kubesphere.io/role-template-rules: '{"users": "manage"}'
     kubesphere.io/alias-name: Users Management
   labels:
@@ -1013,7 +1012,6 @@ kind: GlobalRole
 metadata:
   annotations:
     iam.kubesphere.io/dependencies: '["role-template-view-roles"]'
-    iam.kubesphere.io/module: Access Control
     iam.kubesphere.io/role-template-rules: '{"roles": "manage"}'
     kubesphere.io/alias-name: Roles Management
   labels:
@@ -1623,7 +1621,6 @@ kind: WorkspaceRole
 metadata:
   annotations:
     iam.kubesphere.io/dependencies: '["role-template-view-roles"]'
-    iam.kubesphere.io/module: Access Control
     iam.kubesphere.io/role-template-rules: '{"roles": "manage"}'
     kubesphere.io/alias-name: Workspace Roles Management
   labels:
@@ -2870,7 +2867,6 @@ role:
   metadata:
     annotations:
       iam.kubesphere.io/dependencies: '["role-template-view-roles"]'
-      iam.kubesphere.io/module: Access Control
       iam.kubesphere.io/role-template-rules: '{"roles": "manage"}'
       kubesphere.io/alias-name: Project Roles Management
     labels:

--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -1639,7 +1639,6 @@ apiVersion: iam.kubesphere.io/v1alpha2
 kind: WorkspaceRole
 metadata:
   annotations:
-    iam.kubesphere.io/module: Access Control
     iam.kubesphere.io/role-template-rules: '{"members": "view"}'
     kubesphere.io/alias-name: Workspace Members View
   labels:
@@ -1688,7 +1687,7 @@ apiVersion: iam.kubesphere.io/v1alpha2
 kind: WorkspaceRole
 metadata:
   annotations:
-    iam.kubesphere.io/role-template-rules: '{"basic": "view"}'
+    iam.kubesphere.io/role-template-rules: '{"basic": "view", "members": "view"}'
   labels:
     iam.kubesphere.io/role-template: "true"
   name: role-template-view-basic
@@ -1720,7 +1719,9 @@ rules:
     resources:
       - workspacemembers
     verbs:
+      - get
       - list
+      - watch
 
 ---
 apiVersion: iam.kubesphere.io/v1alpha2

--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -968,9 +968,7 @@ apiVersion: iam.kubesphere.io/v1alpha2
 kind: GlobalRole
 metadata:
   annotations:
-    iam.kubesphere.io/dependencies: '["role-template-view-users","role-template-view-roles"]'
     iam.kubesphere.io/role-template-rules: '{"users": "manage"}'
-    kubesphere.io/alias-name: Users Management
   labels:
     iam.kubesphere.io/role-template: "true"
   name: role-template-manage-users
@@ -1011,9 +1009,7 @@ apiVersion: iam.kubesphere.io/v1alpha2
 kind: GlobalRole
 metadata:
   annotations:
-    iam.kubesphere.io/dependencies: '["role-template-view-roles"]'
     iam.kubesphere.io/role-template-rules: '{"roles": "manage"}'
-    kubesphere.io/alias-name: Roles Management
   labels:
     iam.kubesphere.io/role-template: "true"
   name: role-template-manage-roles
@@ -1620,9 +1616,7 @@ apiVersion: iam.kubesphere.io/v1alpha2
 kind: WorkspaceRole
 metadata:
   annotations:
-    iam.kubesphere.io/dependencies: '["role-template-view-roles"]'
     iam.kubesphere.io/role-template-rules: '{"roles": "manage"}'
-    kubesphere.io/alias-name: Workspace Roles Management
   labels:
     iam.kubesphere.io/role-template: "true"
   name: role-template-manage-roles
@@ -1640,7 +1634,6 @@ kind: WorkspaceRole
 metadata:
   annotations:
     iam.kubesphere.io/role-template-rules: '{"members": "view"}'
-    kubesphere.io/alias-name: Workspace Members View
   labels:
     iam.kubesphere.io/role-template: "true"
   name: role-template-view-members
@@ -1660,9 +1653,7 @@ apiVersion: iam.kubesphere.io/v1alpha2
 kind: WorkspaceRole
 metadata:
   annotations:
-    iam.kubesphere.io/dependencies: '["role-template-view-members","role-template-view-roles"]'
     iam.kubesphere.io/role-template-rules: '{"members": "manage"}'
-    kubesphere.io/alias-name: Workspace Members Management
   labels:
     iam.kubesphere.io/role-template: "true"
   name: role-template-manage-members
@@ -2722,9 +2713,7 @@ role:
   kind: Role
   metadata:
     annotations:
-      iam.kubesphere.io/dependencies: '["role-template-view-members","role-template-view-roles"]'
       iam.kubesphere.io/role-template-rules: '{"members": "manage"}'
-      kubesphere.io/alias-name: Project Members Management
     labels:
       iam.kubesphere.io/role-template: "true"
     name: role-template-manage-members
@@ -2865,9 +2854,7 @@ role:
   kind: Role
   metadata:
     annotations:
-      iam.kubesphere.io/dependencies: '["role-template-view-roles"]'
       iam.kubesphere.io/role-template-rules: '{"roles": "manage"}'
-      kubesphere.io/alias-name: Project Roles Management
     labels:
       iam.kubesphere.io/role-template: "true"
     name: role-template-manage-roles


### PR DESCRIPTION
The purpose of this PR is to remove role-template-manage-users, role-template-manage-roles in GlobalRole, and role-template-view-members in WorkspaceRole.

Following this Issue：
[kubesphere/kubesphere#5054](https://github.com/kubesphere/kubesphere/issues/5054) [kubesphere/kubesphere#5111](https://github.com/kubesphere/kubesphere/issues/5111)