### PR TITLE
Delete globalrole workspace-manager

### DIFF
--- a/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+++ b/roles/ks-core/prepare/files/ks-init/role-templates.yaml
@@ -390,148 +390,6 @@ apiVersion: iam.kubesphere.io/v1alpha2
 kind: GlobalRole
 metadata:
   annotations:
-    iam.kubesphere.io/aggregation-roles: '["role-template-view-workspaces","role-template-manage-workspaces","role-template-view-users"]'
-    kubesphere.io/creator: admin
-  name: workspaces-manager
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - abnormalworkloads
-      - quotas
-      - workloads
-      - volumesnapshots
-      - dashboards
-      - configmaps
-      - endpoints
-      - events
-      - limitranges
-      - namespaces
-      - persistentvolumeclaims
-      - podtemplates
-      - replicationcontrollers
-      - resourcequotas
-      - secrets
-      - serviceaccounts
-      - services
-      - applications
-      - controllerrevisions
-      - deployments
-      - replicasets
-      - statefulsets
-      - daemonsets
-      - meshpolicies
-      - cronjobs
-      - jobs
-      - devopsprojects
-      - devops
-      - 'pipelines'
-      - 'pipelines/runs'
-      - 'pipelines/pipelineruns'
-      - 'pipelines/branches'
-      - 'pipelines/checkScriptCompile'
-      - 'pipelines/consolelog'
-      - 'pipelines/scan'
-      - 'pipelines/sonarstatus'
-      - 'pipelineruns'
-      - 'pipelineruns/nodedetails'
-      - 'checkCron'
-      - 'credentials'
-      - 'credentials/usage'
-      - 'gitrepositories'
-      - s2ibinaries
-      - s2ibinaries/file
-      - s2ibuilders
-      - s2ibuildertemplates
-      - s2iruns
-      - events
-      - ingresses
-      - router
-      - filters
-      - pods
-      - pods/log
-      - pods/exec
-      - pods/containers
-      - namespacenetworkpolicies
-      - workspacenetworkpolicies
-      - networkpolicies
-      - podsecuritypolicies
-      - rolebindings
-      - roles
-      - members
-      - servicepolicies
-      - federatedapplications
-      - federatedconfigmaps
-      - federateddeployments
-      - federatedingresses
-      - federatedjobs
-      - federatedlimitranges
-      - federatednamespaces
-      - federatedpersistentvolumeclaims
-      - federatedreplicasets
-      - federatedsecrets
-      - federatedserviceaccounts
-      - federatedservices
-      - federatedservicestatuses
-      - federatedstatefulsets
-      - federatedworkspaces
-      - workspaces
-      - workspacetemplates
-      - workspaceroles
-      - workspacemembers
-      - workspacemembers/namespaces
-      - workspacemembers/devops
-      - workspacerolebindings
-      - groups
-      - groupbindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - '*'
-    resources:
-      - users
-      - users/loginrecords
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - openpitrix.io
-    resources:
-      - repos
-      - apps
-      - apps/versions
-      - categories
-      - apps/audits
-      - clusters/applications
-    verbs:
-      - '*'
-  - apiGroups:
-      - '*'
-    resources:
-      - clusters
-      - cluster
-    verbs:
-      - list
-  - apiGroups:
-      - monitoring.kubesphere.io
-      - monitoring.coreos.com
-      - metering.kubesphere.io
-      - servicemesh.kubesphere.io
-      - alerting.kubesphere.io
-      - network.kubesphere.io
-      - resources.kubesphere.io
-      - gitops.kubesphere.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-
----
-apiVersion: iam.kubesphere.io/v1alpha2
-kind: GlobalRole
-metadata:
-  annotations:
     iam.kubesphere.io/module: Clusters Management
     iam.kubesphere.io/role-template-rules: '{"clusters": "view"}'
     kubesphere.io/alias-name: Clusters View
@@ -825,12 +683,10 @@ apiVersion: iam.kubesphere.io/v1alpha2
 kind: GlobalRole
 metadata:
   annotations:
-    iam.kubesphere.io/dependencies: '["role-template-view-workspaces"]'
-    iam.kubesphere.io/module: Access Control
     iam.kubesphere.io/role-template-rules: '{"workspaces": "manage"}'
     kubesphere.io/alias-name: Workspaces Management
   labels:
-    iam.kubesphere.io/role-template: "true"
+    iam.kubesphere.io/role-template: "false"
   name: role-template-manage-workspaces
 rules:
   - apiGroups:


### PR DESCRIPTION
Delete globalrole workspace-manager and disable role-template-manage-workspaces for custom roles

Signed-off-by: Wenhao Zhou <wenhaozhou@yunify.com>