### PR TITLE
Add an admission webhook for cluster crd

### DIFF
--- a/roles/ks-core/ks-core/files/ks-core/templates/webhook.yaml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/webhook.yaml
@@ -93,6 +93,42 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  name: cluster.kubesphere.io
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: {{ b64enc $ca.Cert | quote }}
+      service:
+        name: ks-controller-manager
+        namespace: {{ .Release.Namespace }}
+        path: /validate-cluster-kubesphere-io-v1alpha1
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: validating-cluster.kubesphere.io
+    namespaceSelector:
+      matchExpressions:
+        - key: control-plane
+          operator: DoesNotExist
+    objectSelector: {}
+    rules:
+      - apiGroups:
+          - cluster.kubesphere.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - UPDATE
+        resources:
+          - clusters
+        scope: '*'
+    sideEffects: None
+    timeoutSeconds: 30
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
   name: resourcesquotas.quota.kubesphere.io
 webhooks:
   - admissionReviewVersions:

--- a/roles/ks-core/ks-core/tasks/main.yaml
+++ b/roles/ks-core/ks-core/tasks/main.yaml
@@ -72,6 +72,7 @@
     - {ns: "kubesphere-system", kind: "validatingwebhookconfigurations", resource: "users.iam.kubesphere.io", release: "ks-core"}
     - {ns: "kubesphere-system", kind: "validatingwebhookconfigurations", resource: "resourcesquotas.quota.kubesphere.io", release: "ks-core"}
     - {ns: "kubesphere-system", kind: "validatingwebhookconfigurations", resource: "network.kubesphere.io", release: "ks-core"}
+    - {ns: "kubesphere-system", kind: "validatingwebhookconfigurations", resource: "cluster.kubesphere.io", release: "ks-core"}
     - {ns: "kubesphere-system", kind: "users.iam.kubesphere.io", resource: "admin", release: "ks-core"}
   when:
     - helm_release.stdout == "0" and ks_crds.stdout != "0"


### PR DESCRIPTION
Signed-off-by: yzx <946666800@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature


### What this PR does / why we need it:
Add an admission webhook for cluster crd to check cluster ID (kube-system UID) before updating

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
Must be used with the updated ks-controller-manager to avoid cluster crd update failures.
```



see https://github.com/kubesphere/kubesphere/pull/5299