### PR TITLE
Bump tower version to v0.2.1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -85,7 +85,7 @@ kubefed_image: kubefed
 kubefed_image_tag: v0.8.1
 tower_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}"
 tower_image: tower
-tower_image_tag: "v0.2.0"
+tower_image_tag: "v0.2.1"
 post_install_job_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}"
 post_install_job_image: kubectl
 # post_install_job_tag: "v1.19.1"


### PR DESCRIPTION
Update the default version of tower to resolve an occasional issue: https://github.com/kubesphere/tower/pull/46

Need retag `kubespheredev/tower:0.2.1` to `kubesphere/tower:v0.2.1`

/cc @pixiake 