### PR TITLE
set --tls-cipher-suites option in metrics-server for CVE-2016-2183

### DIFF
--- a/roles/metrics-server/files/metrics-server/metrics-server.yaml
+++ b/roles/metrics-server/files/metrics-server/metrics-server.yaml
@@ -134,6 +134,7 @@ spec:
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
         - --kubelet-insecure-tls
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
         image: kubesphere/metrics-server:v0.4.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/roles/metrics-server/templates/metrics-server.yaml.j2
+++ b/roles/metrics-server/templates/metrics-server.yaml.j2
@@ -134,6 +134,7 @@ spec:
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
         - --kubelet-insecure-tls
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
         image: {{ metrics_server_repo }}:{{ metrics_server_tag }}
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
metrics-server 的启动参数设置 --tls-cipher-suites 可以避免 CVE-2016-2183 安全漏洞，如果不加使用 nmap 扫描 4443 端口结果如下

![image](https://user-images.githubusercontent.com/28970198/232456608-e18ee97b-ac0a-4c37-a65b-3ffca8d506b9.png)

指定后扫描结果如下

![image](https://user-images.githubusercontent.com/28970198/232456712-0507ea7b-85a4-41d7-8d0a-4018d6cd8898.png)

此参数设置了加密套件列表，列表内容取于默认生成的参数列表去除不安全的 C 级套件