### PR TITLE
Update tower leader election parameter config

### DIFF
--- a/roles/ks-multicluster/templates/tower.yaml.j2
+++ b/roles/ks-multicluster/templates/tower.yaml.j2
@@ -29,7 +29,6 @@ spec:
             - --ca-cert=/ca.crt
             - --ca-key=/ca.key
             - --v=4
-            - --leader-elect=true
           image: {{ tower_repo }}/{{ tower_image }}:{{ tower_image_tag }}
           imagePullPolicy: IfNotPresent
           name: tower


### PR DESCRIPTION
There's no need to start leader election when there's only one replica

ref https://github.com/kubesphere/kubesphere/issues/5855

/cc @pixiake 