### PR TITLE
[hotfix] make `offline-installation-tool.sh` compatible for mac M1/M2

### DIFF
--- a/scripts/offline-installation-tool.sh
+++ b/scripts/offline-installation-tool.sh
@@ -85,6 +85,9 @@ if [ -z "${ARCH}" ]; then
   aarch64*)
     ARCH=arm64
     ;;
+  arm64*)
+    ARCH=arm64
+    ;;
   armv*)
     ARCH=armv7
     ;;


### PR DESCRIPTION
make `offline-installation-tool.sh` compatible for mac M1/M2 when `uname -m ` under Mac M1/M2 CPU, we shall get an `arm64` as response, which, is un-expected by `offline-installation-tool.sh`