### PR TITLE
update readinessProbe/livenessProbe timeout of argocd servers

### DIFF
--- a/roles/ks-devops/templates/argo-cd-values.yaml.j2
+++ b/roles/ks-devops/templates/argo-cd-values.yaml.j2
@@ -6,8 +6,10 @@ dex:
   image:
     repository: "{{ argocd_dex_repo }}"
   readinessProbe:
+    enabled: true
     timeoutSeconds: 10
   livenessProbe:
+    enabled: true
     timeoutSeconds: 10
 
 controller:

--- a/roles/ks-devops/templates/argo-cd-values.yaml.j2
+++ b/roles/ks-devops/templates/argo-cd-values.yaml.j2
@@ -5,6 +5,16 @@ global:
 dex:
   image:
     repository: "{{ argocd_dex_repo }}"
+  readinessProbe:
+    timeoutSeconds: 10
+  livenessProbe:
+    timeoutSeconds: 10
+
+controller:
+  readinessProbe:
+    timeoutSeconds: 10
+  livenessProbe:
+    timeoutSeconds: 10
 
 applicationSet:
   image:
@@ -13,3 +23,15 @@ applicationSet:
 redis:
   image:
     repository: "{{ argocd_redis_repo }}"
+
+repoServer:
+  readinessProbe:
+    timeoutSeconds: 10
+  livenessProbe:
+    timeoutSeconds: 10
+
+server:
+  readinessProbe:
+    timeoutSeconds: 10
+  livenessProbe:
+    timeoutSeconds: 10


### PR DESCRIPTION
Fix: kubesphere/ks-devops#991

```release-note
update readinessProbe/livenessProbe timeout of argocd servers
```