### PR TITLE
 Update metrics server image version

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -239,7 +239,7 @@ defaultbackend_tag: 1.4
 
 #metrics:
 metrics_server_repo: "{{ base_repo }}{{ namespace_override | default('kubesphere') }}/metrics-server"
-metrics_server_tag: v0.4.2
+metrics_server_tag: v0.4.5
 
 #istio
 istio_hub: "{{ base_repo }}{{ namespace_override | default('istio') }}"

--- a/roles/metrics-server/files/metrics-server/metrics-server.yaml
+++ b/roles/metrics-server/files/metrics-server/metrics-server.yaml
@@ -135,7 +135,7 @@ spec:
         - --kubelet-use-node-status-port
         - --kubelet-insecure-tls
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
-        image: kubesphere/metrics-server:v0.4.2
+        image: kubesphere/metrics-server:v0.4.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
v0.4.2 only supports amd64, v0.4.5 supports more types of CPUs, including am64, amd64, ppcle64, etc.