### PR TITLE
update gatekeeper template

### DIFF
--- a/roles/gatekeeper/files/gatekeeper/templates/gatekeeper-admin-podsecuritypolicy.yaml
+++ b/roles/gatekeeper/files/gatekeeper/templates/gatekeeper-admin-podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -33,3 +34,5 @@ spec:
   - projected
   - secret
   - downwardAPI
+
+{{- end }}

--- a/roles/gatekeeper/files/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
+++ b/roles/gatekeeper/files/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodDisruptionBudget" }}
 apiVersion: policy/v1beta1
+{{- else }}
+apiVersion: policy/v1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
```release-note
Fixed problems with installing Gatekeeper caused by old Kubernetes API versions. It adapts to different Kubernetes versions (tested with v1.24 and v1.28) and selects the right API version to avoid installation errors. This change makes installing Gatekeeper easier and works better with newer Kubernetes versions.
```