### PR TITLE
Fix Apply fluentbit operator custom :Add --recursive flag to avoid the reading error

### DIFF
--- a/roles/ks-auditing/tasks/fluentbit-operator.yaml
+++ b/roles/ks-auditing/tasks/fluentbit-operator.yaml
@@ -45,4 +45,4 @@
 
 - name: ks-auditing | Apply fluentbit operator custom resources
   shell: >
-    {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/fluentbit-operator
+    {{ bin_dir }}/kubectl apply --recursive=true -f {{ kubesphere_dir }}/fluentbit-operator

--- a/roles/ks-events/tasks/fluentbit-operator.yaml
+++ b/roles/ks-events/tasks/fluentbit-operator.yaml
@@ -45,4 +45,4 @@
 
 - name: ks-events | Apply fluentbit operator custom resources
   shell: >
-    {{ bin_dir }}/kubectl apply -f {{ kubesphere_dir }}/fluentbit-operator
+    {{ bin_dir }}/kubectl apply --recursive=true -f {{ kubesphere_dir }}/fluentbit-operator


### PR DESCRIPTION
This PR fixes: #2283 

The logs shows that the kubectl apply fail because it cannot apply the whole `fluentbit-operator` because in this case it contains only sub directories (no yaml or json file are exsiting)